### PR TITLE
utas180305a

### DIFF
--- a/an/PotsTrafficThread.cpp
+++ b/an/PotsTrafficThread.cpp
@@ -120,8 +120,8 @@ public:
 private:
    //  Deleted to prohibit copying.
    //
-   TrafficCall(const TrafficCall& that);
-   TrafficCall& operator=(const TrafficCall& that);
+   TrafficCall(const TrafficCall& that) = delete;
+   TrafficCall& operator=(const TrafficCall& that) = delete;
 
    //> The size of the DelayMsecs_ array.
    //
@@ -243,8 +243,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   TrafficCallPool(const TrafficCallPool& that);
-   TrafficCallPool& operator=(const TrafficCallPool& that);
+   TrafficCallPool(const TrafficCallPool& that) = delete;
+   TrafficCallPool& operator=(const TrafficCallPool& that) = delete;
 
    //  The free queue of calls, which minimizes use of the heap.
    //

--- a/cb/ProxyBcSessions.h
+++ b/cb/ProxyBcSessions.h
@@ -215,11 +215,11 @@ public:
    static const Id ProxyRelease  = FirstId + 3;
    static const Id NextId        = FirstId + 4;
 private:
-   //  Private because this class only has static members.  Its purpose is
+   //  Deleted because this class only has static members.  Its purpose is
    //  to define event identifiers, but the events themselves are derived
    //  from various basic call events.
    //
-   ProxyBcEvent();
+   ProxyBcEvent() = delete;
 };
 
 //  This event is used by services such as call transfer and call forwarding
@@ -384,11 +384,11 @@ public:
    static const Id ProxyAnswerSnp  = FirstId + 2;
    static const Id NextId          = FirstId + 3;
 private:
-   //  Private because this class only has static members.  It defines
+   //  Deleted because this class only has static members.  It defines
    //  trigger identifiers to which active modifier SSMs can react, but
    //  no actual triggers (for Initiators) use these identifiers as yet.
    //
-   ProxyBcTrigger();
+   ProxyBcTrigger() = delete;
 };
 
 //------------------------------------------------------------------------------

--- a/ct/CodeFile.cpp
+++ b/ct/CodeFile.cpp
@@ -2342,14 +2342,7 @@ void CodeFile::LogLine
    //
    if((warning < Warning_N) && (n < lineType_.size()))
    {
-      WarningLog log;
-
-      log.file = this;
-      log.line = n;
-      log.warning = warning;
-      log.offset = offset;
-      log.info = info;
-
+      auto log = WarningLog(this, n, warning, offset, info);
       CodeInfo::AddWarning(log);
    }
 }

--- a/ct/CodeFileSet.cpp
+++ b/ct/CodeFileSet.cpp
@@ -845,7 +845,6 @@ BuildOrderPtr CodeFileSet::SortInBuildOrder() const
    //
    size_t found = 0;
    SetOfIds build;
-   FileLevel item;
 
    BuildOrderPtr order(new BuildOrder);
 
@@ -865,8 +864,7 @@ BuildOrderPtr CodeFileSet::SortInBuildOrder() const
 
             if(it != fileSet.cend())
             {
-               item.fid = fids[i];
-               item.level = level;
+               auto item = FileLevel(fids[i], level);
                order->push_back(item);
             }
 

--- a/ct/CodeWarning.cpp
+++ b/ct/CodeWarning.cpp
@@ -45,6 +45,18 @@ using std::string;
 
 namespace CodeTools
 {
+WarningLog::WarningLog(const CodeFile* file, size_t line,
+   Warning warning, size_t offset, const std::string& info) :
+   file(file),
+   line(line),
+   warning(warning),
+   offset(offset),
+   info(info)
+{
+}
+
+//------------------------------------------------------------------------------
+
 bool WarningLog::operator==(const WarningLog& that) const
 {
    if(this->file != that.file) return false;

--- a/ct/CodeWarning.h
+++ b/ct/CodeWarning.h
@@ -44,6 +44,8 @@ namespace CodeTools
       size_t offset;         // warning-specific; displayed if non-zero
       std::string info;      // warning-specific
 
+      WarningLog(const CodeFile* file, size_t line,
+         Warning warning, size_t offset, const std::string& info);
       bool operator==(const WarningLog& that) const;
       bool operator!=(const WarningLog& that) const;
       bool DisplayCode() const

--- a/ct/CxxArea.cpp
+++ b/ct/CxxArea.cpp
@@ -1319,18 +1319,12 @@ void Class::GetMemberInitAttrs(DataInitVector& members) const
 {
    Debug::ft(Class_GetMemberInitAttrs);
 
-   DataInitAttrs attrs;
-
    auto data = Datas();
 
    for(size_t i = 0; i < data->size(); ++i)
    {
       auto mem = data->at(i).get();
-
-      attrs.member = mem;
-      attrs.initNeeded = !mem->IsDefaultConstructible();
-      attrs.initOrder = 0;
-
+      auto attrs = DataInitAttrs(mem, !mem->IsDefaultConstructible(), 0);
       members.push_back(attrs);
    }
 }

--- a/ct/CxxArea.h
+++ b/ct/CxxArea.h
@@ -229,9 +229,12 @@ private:
 //
 struct DataInitAttrs
 {
-   const Data* member;  // a data member
-   bool initNeeded;     // set if it needs to be explicitly initialized
-   size_t initOrder;    // the order in which it was initialized
+   const Data* const member;  // a data member
+   const bool initNeeded;     // set if it needs to be explicitly initialized
+   size_t initOrder;          // the order in which it was initialized
+
+   DataInitAttrs(const Data* m, bool n, size_t o) :
+      member(m), initNeeded(n), initOrder(o) { }
 };
 
 typedef std::vector< DataInitAttrs > DataInitVector;

--- a/ct/CxxExecute.cpp
+++ b/ct/CxxExecute.cpp
@@ -61,7 +61,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 };
 
 class ArgTrace : public CxxTrace
@@ -73,7 +73,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  The argument associated with the action.
    //
@@ -89,7 +89,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  The token associated with the action.
    //
@@ -105,7 +105,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  The file associated with the action.
    //
@@ -125,7 +125,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  If non-zero, the error associated with the action.
    //
@@ -142,9 +142,9 @@ ActTrace::ActTrace(Action action) : CxxTrace(sizeof(ActTrace), action) { }
 
 //------------------------------------------------------------------------------
 
-bool ActTrace::Display(std::ostream& stream)
+bool ActTrace::Display(std::ostream& stream, bool diff)
 {
-   CxxTrace::Display(stream);
+   CxxTrace::Display(stream, diff);
    return true;
 }
 
@@ -158,9 +158,9 @@ ArgTrace::ArgTrace(Action action, const StackArg& arg) :
 
 //------------------------------------------------------------------------------
 
-bool ArgTrace::Display(std::ostream& stream)
+bool ArgTrace::Display(std::ostream& stream, bool diff)
 {
-   CxxTrace::Display(stream);
+   CxxTrace::Display(stream, diff);
    stream << arg_.Trace();
    return true;
 }
@@ -484,13 +484,13 @@ CxxTrace::CxxTrace(size_t size, Action action) :
 
 //------------------------------------------------------------------------------
 
-bool CxxTrace::Display(std::ostream& stream)
+bool CxxTrace::Display(std::ostream& stream, bool diff)
 {
    auto buff = Singleton< TraceBuffer >::Instance();
 
    if(buff->ToolIsOn(FunctionTracer))
    {
-      TraceRecord::Display(stream);
+      TraceRecord::Display(stream, diff);
       stream << spaces(TraceDump::EvtToObj);
    }
 
@@ -529,9 +529,9 @@ ErrTrace::~ErrTrace()
 
 //------------------------------------------------------------------------------
 
-bool ErrTrace::Display(std::ostream& stream)
+bool ErrTrace::Display(std::ostream& stream, bool diff)
 {
-   CxxTrace::Display(stream);
+   CxxTrace::Display(stream, diff);
 
    if(rid_ == ERROR)
    {
@@ -557,9 +557,9 @@ FileTrace::FileTrace(Action action, const CodeFile& file) :
 
 //------------------------------------------------------------------------------
 
-bool FileTrace::Display(std::ostream& stream)
+bool FileTrace::Display(std::ostream& stream, bool diff)
 {
-   CxxTrace::Display(stream);
+   CxxTrace::Display(stream, diff);
    stream << file_->Name();
    return true;
 }
@@ -1651,9 +1651,9 @@ TokenTrace::TokenTrace(Action action, const CxxToken* token) :
 
 //------------------------------------------------------------------------------
 
-bool TokenTrace::Display(std::ostream& stream)
+bool TokenTrace::Display(std::ostream& stream, bool diff)
 {
-   CxxTrace::Display(stream);
+   CxxTrace::Display(stream, diff);
    stream << token_->Trace();
    return true;
 }

--- a/ct/CxxExecute.h
+++ b/ct/CxxExecute.h
@@ -78,7 +78,7 @@ protected:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  The line number associated with the trace record.
    //
@@ -595,10 +595,10 @@ public:
    //
    static void Startup(NodeBase::RestartLevel level) { }
 private:
-   //  Private because this class (basically a singleton) only has
+   //  Deleted because this class (basically a singleton) only has
    //  static members.
    //
-   Context();
+   Context() = delete;
 
    //  Pushes a parser onto the stack.
    //

--- a/ct/CxxNamed.cpp
+++ b/ct/CxxNamed.cpp
@@ -2173,15 +2173,14 @@ CxxNamed* QualName::ResolveLocal(SymbolView* view) const
    Debug::ft(QualName_ResolveLocal);
 
    auto syms = Singleton< CxxSymbols >::Instance();
-   auto qname = GetQualName();
 
-   if((qname->Size() == 1) && !qname->IsGlobal())
+   if((Size() == 1) && !IsGlobal())
    {
       auto item = syms->FindLocal(*Name(), view);
 
       if(item != nullptr)
       {
-         qname->SetReferentN(0, item, view);
+         SetReferentN(0, item, view);
          return item;
       }
    }

--- a/ct/CxxScope.cpp
+++ b/ct/CxxScope.cpp
@@ -2524,14 +2524,16 @@ void Function::CheckIfDefined() const
    Debug::ft(Function_CheckIfDefined);
 
    //  A function without an implementation is logged as undefined unless
-   //  o it's actually part of a function signature typedef, or
-   //  o it is deleting the default that the compiler would otherwise provide.
+   //  o it's actually part of a function signature typedef;
+   //  o it is deleting the default that the compiler would otherwise provide;
+   //  o it uses the compiler-generated default.
    //  Pure virtual functions are logged separately, because not providing an
    //  implementation may be intentional.
    //
    if(GetDefn()->impl_ != nullptr) return;
    if(type_) return;
    if(IsDeleted()) return;
+   if(defaulted_) return;
 
    if(pure_)
       Log(PureVirtualNotDefined);
@@ -3702,6 +3704,8 @@ fn_name Function_IsDeleted = "Function.IsDeleted";
 bool Function::IsDeleted() const
 {
    Debug::ft(Function_IsDeleted);
+
+   if(deleted_) return true;
 
    //  A private constructor, operator=, or operator new, usually serves to
    //  prohibit stack allocation, copying, or heap allocation, respectively.

--- a/ct/CxxToken.h
+++ b/ct/CxxToken.h
@@ -50,6 +50,8 @@ struct CxxUsageSets
    CxxNamedSet friends;    // types resolved via a friend declaration
    CxxNamedSet users;      // names resolved via a using statement
 
+   CxxUsageSets() = default;  // create empty CxxNamedSets
+
    //  Adds ITEM to the specified set (AddForward adds ITEM to FRIENDS if
    //  it is a friend declaration).  These functions exist so that a debug
    //  breakpoint can be set within them to find the origin of an item.
@@ -357,9 +359,11 @@ public:
    //
    struct Tags
    {
-      Radix radix_ : 8;
-      bool unsigned_ : 8;  // "U" suffix
-      Size size_ : 8;
+      const Radix radix_ : 8;
+      const bool unsigned_ : 8;  // "U" suffix
+      const Size size_ : 8;
+
+      Tags(Radix r, bool u, Size s) : radix_(r), unsigned_(u), size_(s) { }
    };
 
    IntLiteral(int64_t num, const Tags& tags)
@@ -397,6 +401,8 @@ public:
    {
       bool exp_ : 8;  // included an exponent
       Size size_ : 8;
+
+      Tags(bool e, Size s) : exp_(e), size_(s) { }
    };
 
    FloatLiteral(long double num, const Tags& tags)

--- a/ct/Lexer.cpp
+++ b/ct/Lexer.cpp
@@ -756,10 +756,7 @@ bool Lexer::GetNum(TokenPtr& item)
 
    if(!CxxChar::Attrs[c].validInt)
    {
-      IntLiteral::Tags tags;
-      tags.radix_ = IntLiteral::DEC;
-      tags.unsigned_ = false;
-      tags.size_ = IntLiteral::SIZE_I;
+      auto tags = IntLiteral::Tags(IntLiteral::DEC, false, IntLiteral::SIZE_I);
       auto value = CxxChar::Attrs[CurrChar()].intValue;
       if(value < 0) return false;
       item.reset(new IntLiteral(value, tags));
@@ -803,8 +800,7 @@ bool Lexer::GetNum(TokenPtr& item)
       long double fp = num;
       GetFloat(fp);
 
-      FloatLiteral::Tags tags;
-      tags.exp_ = false;
+      auto tags = FloatLiteral::Tags(false, FloatLiteral::SIZE_D);
 
       if(ThisCharIs('E') || ThisCharIs('e'))
       {
@@ -823,8 +819,6 @@ bool Lexer::GetNum(TokenPtr& item)
          tags.size_ = FloatLiteral::SIZE_L;
       else if(ThisCharIs('F') || ThisCharIs('f'))
          tags.size_ = FloatLiteral::SIZE_F;
-      else
-         tags.size_ = FloatLiteral::SIZE_D;
 
       item.reset(new FloatLiteral(fp, tags));
 
@@ -867,10 +861,7 @@ bool Lexer::GetNum(TokenPtr& item)
       }
    }
 
-   IntLiteral::Tags tags;
-   tags.radix_ = radix;
-   tags.unsigned_ = uns;
-   tags.size_ = size;
+   auto tags = IntLiteral::Tags(radix, uns, size);
    item.reset(new IntLiteral(num, tags));
    return Advance();
 }

--- a/ct/LibraryTypes.h
+++ b/ct/LibraryTypes.h
@@ -52,8 +52,10 @@ enum LibSetType
 //
 struct FileLevel
 {
-   NodeBase::id_t fid;  // the file's identifier
-   size_t level;        // the file's level in the build
+   const NodeBase::id_t fid;  // the file's identifier
+   const size_t level;        // the file's level in the build
+
+   FileLevel(NodeBase::id_t f, size_t l) : fid(f), level(l) { }
 };
 
 typedef std::vector< FileLevel > BuildOrder;

--- a/mb/Circuit.h
+++ b/mb/Circuit.h
@@ -82,8 +82,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   Circuit(const Circuit& that);
-   Circuit& operator=(const Circuit& that);
+   Circuit(const Circuit& that) = delete;
+   Circuit& operator=(const Circuit& that) = delete;
 
    //  The port where the circuit appears.
    //

--- a/mb/Tones.h
+++ b/mb/Tones.h
@@ -81,8 +81,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   Tone(const Tone& that);
-   Tone& operator=(const Tone& that);
+   Tone(const Tone& that) = delete;
+   Tone& operator=(const Tone& that) = delete;
 
    //  The tone's identifier.
    //

--- a/nb/CfgParm.h
+++ b/nb/CfgParm.h
@@ -132,7 +132,7 @@ private:
    //  Deleted to prohibit copying.
    //
    CfgParm(const CfgParm& that) = delete;
-   CfgParm& operator=(const CfgParm& that);
+   CfgParm& operator=(const CfgParm& that) = delete;
 
    //  The parameter's tuple (its key and the string used to set its value).
    //

--- a/nb/Debug.h
+++ b/nb/Debug.h
@@ -131,9 +131,9 @@ private:
       StackChecking   // set when stack overflow prevention is active
    };
 
-   //  Private because this class only has static members.
+   //  Deleted because this class only has static members.
    //
-   Debug();
+   Debug() = delete;
 
    //  Used by the various versions of SwErr.
    //

--- a/nb/FunctionTrace.cpp
+++ b/nb/FunctionTrace.cpp
@@ -206,12 +206,17 @@ void FunctionTrace::Capture(fn_name_arg func)
 
 //------------------------------------------------------------------------------
 
-bool FunctionTrace::Display(ostream& stream)
+bool FunctionTrace::Display(ostream& stream, bool diff)
 {
-   if(!TimedRecord::Display(stream)) return false;
+   if(!TimedRecord::Display(stream, diff)) return false;
 
-   stream << setw(TraceDump::TotWidth) << gross_ << TraceDump::Tab();
-   stream << setw(TraceDump::NetWidth) << net_ << TraceDump::Tab();
+   //  Suppress timing information if a >diff is planned.
+   //
+   usecs_t gross = (diff ? 0 : gross_);
+   usecs_t net = (diff ? 0 : net_);
+
+   stream << setw(TraceDump::TotWidth) << gross << TraceDump::Tab();
+   stream << setw(TraceDump::NetWidth) << net << TraceDump::Tab();
 
    auto dispDepth = std::min(depth_, MaxDispDepth);
 

--- a/nb/FunctionTrace.h
+++ b/nb/FunctionTrace.h
@@ -77,7 +77,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 
    //  Mask for selecting FunctionTrace records when using TraceBuffer::Next.
    //

--- a/nb/Log.h
+++ b/nb/Log.h
@@ -48,9 +48,9 @@ public:
    //
    static std::string FileName();
 private:
-   //  Private because this class only has static members.
+   //  Deleted because this class only has static members.
    //
-   Log();
+   Log() = delete;
 };
 }
 #endif

--- a/nb/Memory.h
+++ b/nb/Memory.h
@@ -90,9 +90,9 @@ public:
    //
    static void Shutdown(RestartLevel level);
 private:
-   //  Private because this class only has static members.
+   //  Deleted because this class only has static members.
    //
-   Memory();
+   Memory() = delete;
 
    //  Returns the heap for TYPE.  If it doesn't exist, it is created.
    //

--- a/nb/MemoryTrace.cpp
+++ b/nb/MemoryTrace.cpp
@@ -45,9 +45,9 @@ MemoryTrace::MemoryTrace(Id rid, const void* addr, MemoryType type,
 
 //------------------------------------------------------------------------------
 
-bool MemoryTrace::Display(ostream& stream)
+bool MemoryTrace::Display(ostream& stream, bool diff)
 {
-   if(!TimedRecord::Display(stream)) return false;
+   if(!TimedRecord::Display(stream, diff)) return false;
 
    stream << spaces(TraceDump::EvtToObj) << addr_ << TraceDump::Tab();
    stream << "type=" << TypeString(type_) << spaces(3);

--- a/nb/MemoryTrace.h
+++ b/nb/MemoryTrace.h
@@ -46,7 +46,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string for displaying this type of record.
    //

--- a/nb/ObjectPoolTrace.cpp
+++ b/nb/ObjectPoolTrace.cpp
@@ -46,9 +46,9 @@ ObjectPoolTrace::ObjectPoolTrace(Id rid, const Pooled& obj) :
 
 //------------------------------------------------------------------------------
 
-bool ObjectPoolTrace::Display(ostream& stream)
+bool ObjectPoolTrace::Display(ostream& stream, bool diff)
 {
-   if(!TimedRecord::Display(stream)) return false;
+   if(!TimedRecord::Display(stream, diff)) return false;
 
    auto pool = Singleton< ObjectPoolRegistry >::Instance()->Pool(pid_);
 

--- a/nb/ObjectPoolTrace.h
+++ b/nb/ObjectPoolTrace.h
@@ -50,7 +50,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string explaining the event.
    //

--- a/nb/Restart.h
+++ b/nb/Restart.h
@@ -79,9 +79,9 @@ public:
    //
    static void Initiate(reinit_t reason, debug32_t errval);
 private:
-   //  Private because this class only has static members.
+   //  Deleted because this class only has static members.
    //
-   Restart();
+   Restart() = delete;
 
    //  The state of system initialization or shutdown.
    //

--- a/nb/Singletons.cpp
+++ b/nb/Singletons.cpp
@@ -38,6 +38,8 @@ struct SingletonTuple
 {
    const Base** addr;    // pointer to a singleton's Instance_ pointer
    MemoryType type;      // the type of memory that the singleton uses
+
+   SingletonTuple(const Base** a, MemoryType t) : addr(a), type(t) { }
 };
 
 //------------------------------------------------------------------------------
@@ -89,9 +91,7 @@ void Singletons::BindInstance(const Base** addr, MemoryType type)
 
    //  Add this singleton to the registry.
    //
-   SingletonTuple entry;
-   entry.addr = addr;
-   entry.type = type;
+   auto entry = SingletonTuple(addr, type);
    registry_.PushBack(entry);
 }
 

--- a/nb/SysHeap.h
+++ b/nb/SysHeap.h
@@ -117,10 +117,10 @@ private:
    SysHeap(const SysHeap& that) = delete;
    SysHeap& operator=(const SysHeap& that) = delete;
 
-   //  Overridden to prevent allocation on another heap.
+   //  Deleted to prevent allocation on another heap.
    //
-   static void* operator new(size_t size, MemoryType type);
-   static void* operator new[](size_t size, MemoryType type);
+   static void* operator new(size_t size, MemoryType type) = delete;
+   static void* operator new[](size_t size, MemoryType type) = delete;
 
    //  The type of memory provided by the heap.
    //

--- a/nb/SysSignals.h
+++ b/nb/SysSignals.h
@@ -36,9 +36,9 @@ public:
    //
    static void CreateNativeSignals();
 private:
-   //  Private because this class only has static members.
+   //  Deleted because this class only has static members.
    //
-   SysSignals();
+   SysSignals() = delete;
 
    //  Standard signals.  CreateNativeSignals instantiates a singleton for each
    //  one that this platform supports.  Other signals also exist, but their use

--- a/nb/SysThreadStack.win.cpp
+++ b/nb/SysThreadStack.win.cpp
@@ -76,9 +76,9 @@ public:
    //
    static const size_t MaxFrames = 2048;
 private:
-   //  Private because this class only has static members.
+   //  Deleted because this class only has static members.
    //
-   StackInfo();
+   StackInfo() = delete;
 
    //  A handle to our process.
    //

--- a/nb/Thread.cpp
+++ b/nb/Thread.cpp
@@ -89,7 +89,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(ostream& stream) override;
+   virtual bool Display(ostream& stream, bool diff) override;
 private:
    //  Private to restrict creation to CaptureEvent.
    //
@@ -186,9 +186,9 @@ void ThreadTrace::CaptureEvent(fn_name_arg func, Id rid, word info)
 
 //------------------------------------------------------------------------------
 
-bool ThreadTrace::Display(ostream& stream)
+bool ThreadTrace::Display(ostream& stream, bool diff)
 {
-   if(!FunctionTrace::Display(stream)) return false;
+   if(!FunctionTrace::Display(stream, diff)) return false;
 
    switch(rid_)
    {
@@ -1337,9 +1337,9 @@ fixed_string SchedHeader[SchedHeaderSize] =
 {
 // 0         1         2         3         4         5         6         7
 // 0123456789012345678901234567890123456789012345678901234567890123456789012
-   "      THREADS      |    SINCE START OF CURRENT 15-MIN INTERVAL    | LAST",
-   "                   |            rtc  max   max     max  total     |5 SEC",
-   "id    name host f b| ex yields  t/o msgs stack   usecs  msecs %cpu| %cpu"
+   "      THREADS       |    SINCE START OF CURRENT 15-MIN INTERVAL    | LAST",
+   "                    |            rtc  max   max     max  total     |5 SEC",
+   "id    name  host f b| ex yields  t/o msgs stack   usecs  msecs %cpu| %cpu"
 };
 
 void Thread::DisplaySummaries(ostream& stream)
@@ -1373,7 +1373,7 @@ void Thread::DisplaySummaries(ostream& stream)
    stream << line << CRLF;
 
    stream << setw(10) << "idle";
-   stream << setw(51) << (idle0 + 500) / 1000;
+   stream << setw(52) << (idle0 + 500) / 1000;
    stream << setw(5) << 100 * (double(idle0) / time0);
 
    //  Set TIME1 to the length of the previous short interval.
@@ -1409,7 +1409,7 @@ void Thread::DisplaySummary
 
    stream << setw(2) << Tid();
    stream << setw(8) << AbbrName() << SPACE;
-   stream << setw(4) << strHex(NativeThreadId(), 4, false);
+   stream << setw(5) << strHex(NativeThreadId(), 5, false);
 
    auto f = FactionChar(faction_);
    if(priv_->unpreempts_ == 0) f = tolower(f);

--- a/nb/TimedRecord.cpp
+++ b/nb/TimedRecord.cpp
@@ -45,7 +45,7 @@ TimedRecord::TimedRecord(size_t size, FlagId owner) : TraceRecord(size, owner),
 
 //------------------------------------------------------------------------------
 
-bool TimedRecord::Display(ostream& stream)
+bool TimedRecord::Display(ostream& stream, bool diff)
 {
    auto reg = Singleton< ThreadRegistry >::Instance();
    auto tid = reg->FindThreadId(nid_);
@@ -54,7 +54,7 @@ bool TimedRecord::Display(ostream& stream)
    if((thr != nullptr) && (thr->CalcStatus(false) != TraceIncluded))
       return false;
 
-   stream << GetTime() << TraceDump::Tab();
+   stream << GetTime(diff) << TraceDump::Tab();
    stream << setw(TraceDump::TidWidth) << tid << TraceDump::Tab();
    stream << EventString() << TraceDump::Tab();
    return true;
@@ -62,10 +62,11 @@ bool TimedRecord::Display(ostream& stream)
 
 //------------------------------------------------------------------------------
 
-string TimedRecord::GetTime() const
+string TimedRecord::GetTime(bool diff) const
 {
    //  Convert our tick timestamp to hh:mm:ss.mmm and remove the hours.
    //
+   if(diff) return "00:00.000";
    return Clock::TicksToTime(ticks_, MinsField);
 }
 

--- a/nb/TimedRecord.h
+++ b/nb/TimedRecord.h
@@ -56,8 +56,9 @@ public:
    SysThreadId Nid() const { return nid_; }
 
    //  Returns the time (mins:secs.msecs) at which the event occurred.
+   //  Returns "00:00.000" if DIFF is set.
    //
-   std::string GetTime() const;
+   std::string GetTime(bool diff) const;
 
    //  Returns the thread identifier associated with the event.
    //
@@ -67,7 +68,7 @@ public:
    //  nothing and returns false if the thread is to be excluded from this
    //  trace.  May be overridden, but this version should be invoked first.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 protected:
    //  See TraceRecord for a description of the arguments.  Protected
    //  because this class is virtual.

--- a/nb/TraceBuffer.cpp
+++ b/nb/TraceBuffer.cpp
@@ -62,7 +62,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 };
 
 //------------------------------------------------------------------------------
@@ -84,7 +84,7 @@ BufferTrace::BufferTrace() : TraceRecord(sizeof(BufferTrace), ToolBuffer)
 const string NilTraceStr("ERROR: invalid trace record");
 const string ResumeTraceStr("BREAK OF TRACE " + string(65,'='));
 
-bool BufferTrace::Display(ostream& stream)
+bool BufferTrace::Display(ostream& stream, bool diff)
 {
    switch(rid_)
    {
@@ -329,7 +329,7 @@ TraceRc TraceBuffer::ClearTools()
 
 fn_name TraceBuffer_DisplayTrace = "TraceBuffer.DisplayTrace";
 
-TraceRc TraceBuffer::DisplayTrace(ostream* stream)
+TraceRc TraceBuffer::DisplayTrace(ostream* stream, bool diff)
 {
    Debug::ft(TraceBuffer_DisplayTrace);
 
@@ -341,7 +341,7 @@ TraceRc TraceBuffer::DisplayTrace(ostream* stream)
       stream = stream_.get();
    }
 
-   auto rc = TraceDump::Generate(*stream);
+   auto rc = TraceDump::Generate(*stream, diff);
    stream_.reset();
    return rc;
 }
@@ -372,7 +372,7 @@ void TraceBuffer::ImmediateDisplay()
    while(lastRecord_ != nullptr)
    {
       if(lastRecord_->rid_ == TraceRecord::InvalidId) return;
-      if(lastRecord_->Display(*stream_)) *stream_ << CRLF;
+      if(lastRecord_->Display(*stream_, false)) *stream_ << CRLF;
       Next(lastRecord_, mask);
    }
 }

--- a/nb/TraceBuffer.h
+++ b/nb/TraceBuffer.h
@@ -158,7 +158,7 @@ public:
    //  Displays all of the records in the trace buffer.  STREAM must be
    //  valid unless an immediate trace is in progress.
    //
-   TraceRc DisplayTrace(std::ostream* stream);
+   TraceRc DisplayTrace(std::ostream* stream, bool diff);
 
    //  Returns true if trace records are being output immediately.
    //

--- a/nb/TraceDump.cpp
+++ b/nb/TraceDump.cpp
@@ -47,7 +47,7 @@ fixed_string BlockedStr = "Functions not captured because buffer was locked: ";
 
 fn_name TraceDump_Generate = "TraceDump.Generate";
 
-TraceRc TraceDump::Generate(ostream& stream)
+TraceRc TraceDump::Generate(ostream& stream, bool diff)
 {
    Debug::ft(TraceDump_Generate);
 
@@ -82,7 +82,7 @@ TraceRc TraceDump::Generate(ostream& stream)
       {
          if(buff->ToolIsOn(rec->Owner()))
          {
-            if(rec->Display(stream)) stream << CRLF;
+            if(rec->Display(stream, diff)) stream << CRLF;
          }
       }
    }

--- a/nb/TraceDump.h
+++ b/nb/TraceDump.h
@@ -56,7 +56,7 @@ namespace TraceDump
 
    //  Displays the records in the trace buffer.
    //
-   TraceRc Generate(std::ostream& stream);
+   TraceRc Generate(std::ostream& stream, bool diff);
 }
 }
 #endif

--- a/nb/TraceRecord.cpp
+++ b/nb/TraceRecord.cpp
@@ -43,7 +43,7 @@ TraceRecord::TraceRecord(size_t size, FlagId owner) :
 
 //------------------------------------------------------------------------------
 
-bool TraceRecord::Display(ostream& stream)
+bool TraceRecord::Display(ostream& stream, bool diff)
 {
    stream << spaces(TraceDump::StartToEvt) << EventString() << TraceDump::Tab();
    return true;

--- a/nb/TraceRecord.h
+++ b/nb/TraceRecord.h
@@ -69,12 +69,13 @@ public:
    //
    void Nullify() { owner_ = NIL_ID; }
 
-   //  Invoked to display the record in STREAM when the trace is printed.
-   //  A subclass must begin by invoking TraceRecord::Display.  Returns
-   //  false if nothing was displayed, which suppresses insertion of an
-   //  endline.
+   //  Invoked to display the record in STREAM.  DIFF is set to suppress
+   //  output (e.g. timing information) that would result in undesirable
+   //  mismatches in a >diff between traces.  A subclass must begin by
+   //  invoking TraceRecord::Display.  Returns false if nothing was
+   //  displayed, which suppresses insertion of an endline.
    //
-   virtual bool Display(std::ostream& stream);
+   virtual bool Display(std::ostream& stream, bool diff);
 
    //  Overridden to allocate space in the trace buffer.
    //

--- a/nw/NwTrace.cpp
+++ b/nw/NwTrace.cpp
@@ -66,9 +66,9 @@ NwTrace::NwTrace(Id rid, const SysSocket* socket, word data, ipport_t port,
 
 //------------------------------------------------------------------------------
 
-bool NwTrace::Display(ostream& stream)
+bool NwTrace::Display(ostream& stream, bool diff)
 {
-   if(!TimedRecord::Display(stream)) return false;
+   if(!TimedRecord::Display(stream, diff)) return false;
 
    stream << spaces(TraceDump::EvtToObj);
 

--- a/nw/NwTrace.h
+++ b/nw/NwTrace.h
@@ -77,7 +77,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string for displaying this type of record.
    //

--- a/nw/SysSocket.h
+++ b/nw/SysSocket.h
@@ -200,8 +200,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   SysSocket(const SysSocket& that);
-   SysSocket& operator=(const SysSocket& that);
+   SysSocket(const SysSocket& that) = delete;
+   SysSocket& operator=(const SysSocket& that) = delete;
 
    //  Sets or clears tracing_ and returns the new setting.
    //

--- a/output/help.cli.txt
+++ b/output/help.cli.txt
@@ -201,6 +201,7 @@ save              : Saves what was captured by trace tools.
 (                 : what to save...
   trace           : events captured by tools that are currently ON
     <str>         : filename for output
+    [t|f]         : suppress time values: useful for >diff (default=f)
 )
 
 if                : Executes rest of input line if condition is true.
@@ -259,6 +260,7 @@ save              : Saves what was captured by trace tools.
 (                 : what to save...
   trace           : events captured by tools that are currently ON
     <str>         : filename for output
+    [t|f]         : suppress time values: useful for >diff (default=f)
   funcs           : function call statistics
     <str>         : filename for output
   [               : how to sort (default=calls)
@@ -701,6 +703,7 @@ save              : Saves what was captured by trace tools.
 (                 : what to save...
   trace           : events captured by tools that are currently ON
     <str>         : filename for output
+    [t|f]         : suppress time values: useful for >diff (default=f)
   funcs           : function call statistics
     <str>         : filename for output
   [               : how to sort (default=calls)

--- a/output/rsc.check.txt
+++ b/output/rsc.check.txt
@@ -1,22 +1,22 @@
 LINE COUNTS
- source code   61699
-       blank   35111
-          //   14890
+ source code   61705
+       blank   35119
+          //   14891
   license //    8541
-separator //    6842
+separator //    6843
    tagged //     204
-     text //   16340
+     text //   16344
           /*       0
-           {   12078
-           }   10494
-          };    1587
+           {   12080
+           }   10495
+          };    1588
    Debug::ft    3904
      fn_name    3883
     ...split      94
     #include    5180
     #<other>     998
        using     690
-       TOTAL  182535
+       TOTAL  182559
 
 WARNING COUNTS
   W004    76  C-style cast
@@ -47,10 +47,10 @@ WARNING COUNTS
   W049    29  Data is init-only
   W050     1  Data is write-only
   W052    24  Data is not private
-  W055    73  Data could be const
-  W056    15  Data could be const pointer
-  W058    30  Default constructor invoked: POD members not initialized
-  W059     4  Default constructor invoked
+  W055    77  Data could be const
+  W056    16  Data could be const pointer
+  W058    23  Default constructor invoked: POD members not initialized
+  W059     1  Default constructor invoked
   W060    19  Default copy constructor invoked
   W061    15  Default assignment operator invoked
   W062    65  Base class constructor is public
@@ -76,7 +76,7 @@ W004 C-style cast
   C:/Users/gregu/Documents/rsc/rsc/an/PotsTrafficThread.cpp(1076):    timewheel_ = (Q1Way< TrafficCall >*) Memory::Alloc(size, MemDyn);
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp(535):    LibrarySet* nbSet = (LibrarySet*) this;
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp(567):    LibrarySet* nsSet = (LibrarySet*) this;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(441):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(444):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h(1169):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.h(333):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(1220):    return (CxxToken*) this;
@@ -91,7 +91,7 @@ W004 C-style cast
   C:/Users/gregu/Documents/rsc/rsc/nb/Algorithms.cpp(77):    return ((const_ptr_t) ptr1 - (const_ptr_t) ptr2);
   C:/Users/gregu/Documents/rsc/rsc/nb/Class.cpp(220):    if(addr != nullptr) return (Object*) addr;
   C:/Users/gregu/Documents/rsc/rsc/nb/CliPtrParm.cpp(98):          p = (void*) n;
-  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(386):          auto src = (ptr_t) this;
+  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(391):          auto src = (ptr_t) this;
   C:/Users/gregu/Documents/rsc/rsc/nb/Memory.cpp(225):    auto seg = (Segment*) addr;
   C:/Users/gregu/Documents/rsc/rsc/nb/Memory.cpp(282):    auto segment = (Segment*) getptr1(addr, SegmentHeader::Size());
   C:/Users/gregu/Documents/rsc/rsc/nb/Memory.cpp(333):    auto source = (Segment*) getptr1(addr, SegmentHeader::Size());
@@ -155,9 +155,9 @@ W005 Functional cast
   C:/Users/gregu/Documents/rsc/rsc/cb/DigitString.cpp(139):       auto rc = AddDigit(Digit(ds.digits_[i]));
   C:/Users/gregu/Documents/rsc/rsc/cb/DigitString.cpp(171):    if(i < Size()) return Digit(digits_[i]);
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(1724):       *cli.obuf << ": " << Warning(item->warning);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(167):       *stream << setw(12) << LineType(t)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(179):          *stream << setw(6) << WarningCode(Warning(w)) << setw(6)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(180):             << WarningCounts_[w] << spaces(2) << Warning(w) << CRLF;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(179):       *stream << setw(12) << LineType(t)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(191):          *stream << setw(6) << WarningCode(Warning(w)) << setw(6)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(192):             << WarningCounts_[w] << spaces(2) << Warning(w) << CRLF;
   C:/Users/gregu/Documents/rsc/rsc/ct/Cxx.cpp(260):       if(Attrs[i].symbol.compare(sym) == 0) return Cxx::Operator(i);
   C:/Users/gregu/Documents/rsc/rsc/ct/Cxx.cpp(312):          oper = Cxx::Operator(i);
   C:/Users/gregu/Documents/rsc/rsc/ct/Cxx.cpp(363):       Attrs[ValidIntDigits[i]].intValue = int8_t(i);
@@ -167,13 +167,13 @@ W005 Functional cast
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(1380):    if(arrays_ != nullptr) count += TagCount(arrays_->size());
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.cpp(823):          stream << uint64_t(num_);
   C:/Users/gregu/Documents/rsc/rsc/ct/Interpreter.cpp(148):          type = LibTokenType(i);
-  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(932):          oper = Cxx::Operator(match->second);
+  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(923):          oper = Cxx::Operator(match->second);
   C:/Users/gregu/Documents/rsc/rsc/mb/Tones.h(63):    Id Tid() const { return Id(tid_.GetId()); }
   C:/Users/gregu/Documents/rsc/rsc/nb/ModuleRegistry.cpp(106):          return RestartLevel(errval_);
   C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(484):       rc = nbt->SelectFaction(Faction(id), TraceDefault);
   C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(692):       rc = nbt->SelectFaction(Faction(id), TraceExcluded);
   C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(1089):       rc = nbt->SelectFaction(Faction(id), TraceIncluded);
-  C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(2440):       auto heap = Memory::Heap(MemoryType(m));
+  C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(2452):       auto heap = Memory::Heap(MemoryType(m));
   C:/Users/gregu/Documents/rsc/rsc/nb/NbTracer.cpp(207):             stream << Faction(f) << CRLF;
   C:/Users/gregu/Documents/rsc/rsc/nb/ObjectPool.h(97):    ObjectPoolId Pid() const { return ObjectPoolId(pid_.GetId()); }
   C:/Users/gregu/Documents/rsc/rsc/nb/SysTime.cpp(362):          Truncate(TimeField(int(field) + 1));
@@ -327,8 +327,8 @@ W007 Cast down the inheritance hierarchy
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(249):                auto type = static_cast< const Typedef* >(*item2);
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(272):          auto type = static_cast< const Typedef* >(*item1);
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(521):    affecterIds_ = static_cast< CodeFileSet* >(asSet)->Set();
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(2483):    auto& affecterIds = static_cast< CodeFileSet* >(affecterSet)->Set();
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(2621):       auto base = static_cast< const Class* >(*b);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(2476):    auto& affecterIds = static_cast< CodeFileSet* >(affecterSet)->Set();
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(2614):       auto base = static_cast< const Class* >(*b);
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp(78):    auto curr = static_cast< CodeFileSet* >(Users(true));
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp(90):       curr = static_cast< CodeFileSet* >(prev->Users(true));
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp(110):    auto curr = static_cast< CodeFileSet* >(UsedBy(true));
@@ -348,9 +348,9 @@ W007 Cast down the inheritance hierarchy
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1016):    auto area = static_cast< CxxArea* >(GetScope());
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1019):    if(inst != nullptr) return static_cast< ClassInst* >(inst);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1036):          auto c = static_cast< Class* >(*s);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1960):       auto func = static_cast< const Function* >(item);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1986):       auto func = static_cast< const Function* >(item);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(838):       const { return static_cast< Namespace* >(GetScope()); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1954):       auto func = static_cast< const Function* >(item);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1980):       auto func = static_cast< const Function* >(item);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(841):       const { return static_cast< Namespace* >(GetScope()); }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.cpp(872):       auto macro = static_cast< Macro* >(ref_);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.cpp(885):       auto macro = static_cast< Macro* >(ref_);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(1294):       auto thisClass = static_cast< Class* >(thisRoot);
@@ -371,11 +371,11 @@ W007 Cast down the inheritance hierarchy
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(1344):          auto op = static_cast< Operation* >(expr);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(1638):       if(anon) StackArg::SetAutoTypeFor(static_cast< FuncData& >(*next_));
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(1684):    auto data = static_cast< FuncData* >(next_.get());
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(2561):       if(!static_cast< Function* >(item)->virtual_)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(2962):             static_cast< ClassData* >(data)->SetInit(m->get());
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3173):    return static_cast< Function* >((*cti)->FindInstanceAnalog(this));
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4456):       auto func = static_cast< ClassInst* >(cls)->FindTemplateAnalog(this);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4457):       if(func != nullptr) ++static_cast< Function* >(func)->calls_;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(2563):       if(!static_cast< Function* >(item)->virtual_)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(2964):             static_cast< ClassData* >(data)->SetInit(m->get());
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3175):    return static_cast< Function* >((*cti)->FindInstanceAnalog(this));
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4460):       auto func = static_cast< ClassInst* >(cls)->FindTemplateAnalog(this);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4461):       if(func != nullptr) ++static_cast< Function* >(func)->calls_;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(93):          auto func = static_cast< Function* >(GetScope());
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(265):    GetClass()->AddSubclass(static_cast< Class* >(Context::Scope()));
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(299):    return static_cast< Class* >(name_->GetReferent());
@@ -414,8 +414,8 @@ W007 Cast down the inheritance hierarchy
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.cpp(2309):       static_cast< QualName* >(arg2.item)->MemberAccessed(cls, mem);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.cpp(2332):          mem = static_cast< Function* >(mem)->InstantiateFunction(tmplt);
   C:/Users/gregu/Documents/rsc/rsc/ct/Editor.cpp(644):          (const_cast< CxxNamed* >(ref))->OuterSpace();
-  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(1604):          auto def = static_cast< Define* >(item);
-  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(1608):             auto code = const_cast< string* >(source_);
+  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(1595):          auto def = static_cast< Define* >(item);
+  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(1599):             auto code = const_cast< string* >(source_);
   C:/Users/gregu/Documents/rsc/rsc/ct/Library.cpp(95):       (static_cast< CfgStrParm* >(reg->FindParm("SourcePath")));
   C:/Users/gregu/Documents/rsc/rsc/ct/Parser.cpp(365):    auto op = static_cast< Operation* >(call.get());
   C:/Users/gregu/Documents/rsc/rsc/ct/Parser.cpp(617):    auto brace = static_cast< BraceInit* >(token.get());
@@ -455,11 +455,11 @@ W007 Cast down the inheritance hierarchy
   C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(91):       auto curr = static_cast< FunctionTrace* >(rec);
   C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(125):       auto curr = static_cast< FunctionTrace* >(rec);
   C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(189):                   auto last = static_cast< const FunctionTrace* >(rec);
-  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(261):       auto curr = static_cast< FunctionTrace* >(rec);
-  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(300):          curr = static_cast< FunctionTrace* >(rec);
-  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(368):       curr = static_cast< FunctionTrace* >(rec);
-  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(421):          auto curr = static_cast< FunctionTrace* >(rec);
-  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(486):          auto curr = static_cast< FunctionTrace* >(rec);
+  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(266):       auto curr = static_cast< FunctionTrace* >(rec);
+  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(305):          curr = static_cast< FunctionTrace* >(rec);
+  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(373):       curr = static_cast< FunctionTrace* >(rec);
+  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(426):          auto curr = static_cast< FunctionTrace* >(rec);
+  C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp(491):          auto curr = static_cast< FunctionTrace* >(rec);
   C:/Users/gregu/Documents/rsc/rsc/nb/LogThread.cpp(89):       auto req = static_cast< StreamRequest* >(msg);
   C:/Users/gregu/Documents/rsc/rsc/nb/MemoryTrace.cpp(66):       auto curr = static_cast< MemoryTrace* >(rec);
   C:/Users/gregu/Documents/rsc/rsc/nb/StatisticsRegistry.cpp(62):       (static_cast< CfgFileTimeParm* >(reg->FindParm("StatsFileName")));
@@ -802,21 +802,21 @@ W008 Cast removes const qualification
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp(535):    LibrarySet* nbSet = (LibrarySet*) this;
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp(567):    LibrarySet* nsSet = (LibrarySet*) this;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1233):    return const_cast< Class* >(this);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1358):    return static_cast< CxxScope* >(const_cast< Class* >(this));
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1956):       return const_cast< ClassInst* >(this);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1352):    return static_cast< CxxScope* >(const_cast< Class* >(this));
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1950):       return const_cast< ClassInst* >(this);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(144):       override { return const_cast< CxxArea* >(this); }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(441):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(477):       override { return const_cast< Class* >(this); }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(875):       override { return const_cast< Namespace* >(this); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(444):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(480):       override { return const_cast< Class* >(this); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(878):       override { return const_cast< Namespace* >(this); }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(1029):    return const_cast< DataSpec* >(this);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(1422):    const_cast< DataSpec* >(this)->FindReferent();
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2586):    return const_cast< TypeName* >(this);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2585):    return const_cast< TypeName* >(this);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h(801):       override { return const_cast< QualName* >(this); }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h(1169):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(2108):    return FoundFunc(const_cast< Function* >(this), args, match);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3137):    auto prev = const_cast< Function* >(this);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3314):       (const_cast< Function* >(this));
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3568):    func->SetTemplate(const_cast< Function* >(this));
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3139):    auto prev = const_cast< Function* >(this);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3316):       (const_cast< Function* >(this));
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3570):    func->SetTemplate(const_cast< Function* >(this));
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.h(333):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.h(1132):       const override { return const_cast< Function* >(this); }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(1220):    return (CxxToken*) this;
@@ -830,9 +830,9 @@ W008 Cast removes const qualification
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.h(967):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.h(1044):    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.cpp(298):    CxxToken* prev = const_cast< CxxToken* >(this);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(284):    virtual CxxToken* RootType() const { return const_cast< CxxToken* >(this); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(286):    virtual CxxToken* RootType() const { return const_cast< CxxToken* >(this); }
   C:/Users/gregu/Documents/rsc/rsc/ct/Editor.cpp(644):          (const_cast< CxxNamed* >(ref))->OuterSpace();
-  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(1608):             auto code = const_cast< string* >(source_);
+  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(1599):             auto code = const_cast< string* >(source_);
   C:/Users/gregu/Documents/rsc/rsc/nb/Algorithms.cpp(33):    return (void*) ((const_ptr_t) ptr2 - diff);
   C:/Users/gregu/Documents/rsc/rsc/nb/Algorithms.cpp(40):    return (void*) ((const_ptr_t) ptr1 + diff);
   C:/Users/gregu/Documents/rsc/rsc/nb/Base.cpp(98):       objects[count++] = const_cast< Base* >(this);
@@ -1550,7 +1550,7 @@ W033 Unused function
   C:/Users/gregu/Documents/rsc/rsc/cb/BcProtocol.h(316):    virtual CliText* CreateText() const override;
   C:/Users/gregu/Documents/rsc/rsc/cb/BcProtocol.h(369):    virtual CliText* CreateText() const override;
   C:/Users/gregu/Documents/rsc/rsc/cb/ProxyBcSessions.h(192):    explicit ProxyBcDisconnecting(ServiceId sid);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(48):       bool operator!=(const WarningLog& that) const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(50):       bool operator!=(const WarningLog& that) const;
   C:/Users/gregu/Documents/rsc/rsc/ct/Cxx.h(423):    Numeric(NumericType type, size_t width, bool sign)
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.h(129):    size_t Arrays() const;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.h(269):    bool operator!=(const StackArg& that) const;
@@ -1616,7 +1616,7 @@ W033 Unused function
   C:/Users/gregu/Documents/rsc/rsc/nb/Thread.h(122):    static std::atomic_uint32_t* Vector();
   C:/Users/gregu/Documents/rsc/rsc/nb/Thread.h(170):    bool ChangeFaction(Faction faction);
   C:/Users/gregu/Documents/rsc/rsc/nb/TraceBuffer.h(169):    const SysTime& StartTimeFull() const { return startTime_; }
-  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(96):    static void operator delete(void* addr, void* where) { }
+  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(97):    static void operator delete(void* addr, void* where) { }
   C:/Users/gregu/Documents/rsc/rsc/nw/IpService.h(79):    virtual CliText* CreateText() const = 0;
   C:/Users/gregu/Documents/rsc/rsc/nw/IpServiceRegistry.h(50):    IpService* GetService(const std::string& name) const;
   C:/Users/gregu/Documents/rsc/rsc/nw/SysIpL3Addr.h(110):    bool operator!=(const SysIpL3Addr& that) const;
@@ -1712,13 +1712,13 @@ W044 Member could be private
   C:/Users/gregu/Documents/rsc/rsc/cb/ServiceCodeRegistry.h(46):    void SetService(Address::SC sc, ServiceId sid);
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.h(108):    bool IsTemplateHeader() const;
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.h(212):    int CalcGroup(const Include& incl) const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(76):       static bool IsSortedByFile
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(78):       static bool IsSortedByFile
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(119):    Typedef* FindType(const std::string& name) const;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(164):    Enum* FindEnum(const std::string& name) const;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(168):    Enumerator* FindEnumerator(const std::string& name) const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(362):    Function* FindFuncByRole(FunctionRole role, bool base) const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(366):    FunctionDefinition GetFuncDefinition(const Function* func) const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(843):    Namespace* FindNamespace(const std::string& name) const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(365):    Function* FindFuncByRole(FunctionRole role, bool base) const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(369):    FunctionDefinition GetFuncDefinition(const Function* func) const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(846):    Namespace* FindNamespace(const std::string& name) const;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.h(240):    virtual CxxToken* GetValue() const = 0;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.h(280):    virtual CxxToken* RootType() const override { return GetValue(); }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.h(268):    bool operator==(const StackArg& that) const;
@@ -1751,7 +1751,7 @@ W044 Member could be private
   C:/Users/gregu/Documents/rsc/rsc/nb/Class.h(66):    virtual Object* GetQuasiSingleton();
   C:/Users/gregu/Documents/rsc/rsc/nb/Class.h(113):    virtual Object* New(size_t size);
   C:/Users/gregu/Documents/rsc/rsc/nb/CliText.h(61):    const char* HelpText() const;
-  C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(1892):    static void SendAckToOutputFile(const CliThread& cli);
+  C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(1904):    static void SendAckToOutputFile(const CliThread& cli);
   C:/Users/gregu/Documents/rsc/rsc/nb/NbTracer.h(77):    static bool ThreadsEmpty();
   C:/Users/gregu/Documents/rsc/rsc/nb/Object.h(70):    typedef uint32_t InstanceId;  // identifies an object within a Class
   C:/Users/gregu/Documents/rsc/rsc/nb/Object.h(71):    typedef uint32_t ObjectId;    // ClassId (12 bits) + InstanceId (20 bits)
@@ -1771,8 +1771,8 @@ W044 Member could be private
   C:/Users/gregu/Documents/rsc/rsc/nb/Thread.h(162):    SysThreadId NativeThreadId() const;
   C:/Users/gregu/Documents/rsc/rsc/nb/Thread.h(239):    static ptrdiff_t CellDiff();
   C:/Users/gregu/Documents/rsc/rsc/nb/TraceBuffer.h(178):    typedef std::map< fn_name_arg, size_t > InvocationsTable;
-  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(87):    static void operator delete(void* addr) { }
-  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(91):    static void* operator new(size_t size, void* where);
+  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(88):    static void operator delete(void* addr) { }
+  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(92):    static void* operator new(size_t size, void* where);
   C:/Users/gregu/Documents/rsc/rsc/nt/NtIncrement.cpp(3278):    typedef id_t Test;
   C:/Users/gregu/Documents/rsc/rsc/nt/NtIncrement.h(163):    virtual void ConcludeTest(CliThread& cli) const;
   C:/Users/gregu/Documents/rsc/rsc/nw/IoThread.h(97):    virtual bool ExitOnRestart(RestartLevel level) const override;
@@ -1923,7 +1923,7 @@ W049 Data is init-only
   C:/Users/gregu/Documents/rsc/rsc/nb/FileThread.cpp(287):    FunctionGuard
   C:/Users/gregu/Documents/rsc/rsc/nb/InitThread.cpp(307):    FunctionGuard guard(FunctionGuard::MakeUnpreemptable);
   C:/Users/gregu/Documents/rsc/rsc/nb/LogThread.cpp(156):    FunctionGuard
-  C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(1696):    FunctionGuard guard(FunctionGuard::MakePreemptable, yield);
+  C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(1708):    FunctionGuard guard(FunctionGuard::MakePreemptable, yield);
   C:/Users/gregu/Documents/rsc/rsc/nb/NbModule.h(64):    static bool Registered;
   C:/Users/gregu/Documents/rsc/rsc/nb/Singleton.h(130):    static T* Instance_;
   C:/Users/gregu/Documents/rsc/rsc/nb/Thread.cpp(482):    MutexGuard guard(&lock_);
@@ -1950,7 +1950,7 @@ W052 Data is not private
   C:/Users/gregu/Documents/rsc/rsc/nb/Statistics.h(93):    std::atomic_uint32_t prev_;
   C:/Users/gregu/Documents/rsc/rsc/nb/Statistics.h(97):    std::atomic_uint64_t total_;
   C:/Users/gregu/Documents/rsc/rsc/nb/Statistics.h(101):    uint32_t divisor_;
-  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(133):    Id rid_ : 8;
+  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(134):    Id rid_ : 8;
   C:/Users/gregu/Documents/rsc/rsc/nw/IoThread.h(101):    const ipport_t port_;
   C:/Users/gregu/Documents/rsc/rsc/nw/IoThread.h(106):    IpPort* ipPort_;
   C:/Users/gregu/Documents/rsc/rsc/nw/IoThread.h(110):    size_t rxSize_;
@@ -1970,6 +1970,10 @@ W055 Data could be const
   C:/Users/gregu/Documents/rsc/rsc/an/PotsTrafficThread.cpp(172):    Q1Link link_;
   C:/Users/gregu/Documents/rsc/rsc/cb/BcSessions.h(338):    Progress::Ind progress_;
   C:/Users/gregu/Documents/rsc/rsc/cb/BcSessions.h(354):    Cause::Ind cause_;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(42):       size_t line;           // line where warning occurred
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(43):       Warning warning;       // type of warning
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(44):       size_t offset;         // warning-specific; displayed if non-zero
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(45):       std::string info;      // warning-specific
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.h(301):    CxxToken* via_;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h(85):    bool const_ : 1;       // type is const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h(86):    bool constptr_ : 1;    // pointer is const
@@ -2041,6 +2045,7 @@ W055 Data could be const
   C:/Users/gregu/Documents/rsc/rsc/st/MscContext.h(144):    Q1Link link_;
   C:/Users/gregu/Documents/rsc/rsc/st/MscContextPair.h(85):    Q1Link link_;
 W056 Data could be const pointer
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(41):       const CodeFile* file;  // file where warning occurred
   C:/Users/gregu/Documents/rsc/rsc/nb/CfgParm.h(143):    const char* default_;
   C:/Users/gregu/Documents/rsc/rsc/nb/CfgParm.h(147):    const char* expl_;
   C:/Users/gregu/Documents/rsc/rsc/nb/CliCharParm.h(69):    const char* chars_;
@@ -2058,13 +2063,6 @@ W056 Data could be const pointer
   C:/Users/gregu/Documents/rsc/rsc/sb/Factory.h(271):    const char* name_;
 W058 Default constructor invoked: POD members not initialized
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeDir.win.cpp(56):    _finddata_t fileAttrs;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(2345):       WarningLog log;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp(848):    FileLevel item;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1322):    DataInitAttrs attrs;
-  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(759):       IntLiteral::Tags tags;
-  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(806):       FloatLiteral::Tags tags;
-  C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp(870):    IntLiteral::Tags tags;
-  C:/Users/gregu/Documents/rsc/rsc/nb/Singletons.cpp(92):    SingletonTuple entry;
   C:/Users/gregu/Documents/rsc/rsc/nb/SysTickTimer.win.cpp(44):    LARGE_INTEGER frequency;
   C:/Users/gregu/Documents/rsc/rsc/nb/SysTickTimer.win.cpp(75):       LARGE_INTEGER now;
   C:/Users/gregu/Documents/rsc/rsc/nb/SysTickTimer.win.cpp(81):       _timeb now;
@@ -2088,15 +2086,12 @@ W058 Default constructor invoked: POD members not initialized
   C:/Users/gregu/Documents/rsc/rsc/sb/TlvMessage.cpp(336):    ParmIterator pit;
   C:/Users/gregu/Documents/rsc/rsc/sb/TlvMessage.cpp(397):    ParmIterator locpit;
 W059 Default constructor invoked
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(2782):    CxxUsageSets symbols;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3353):    CxxUsageSets usages;
-  C:/Users/gregu/Documents/rsc/rsc/ct/Editor.cpp(363):    CxxUsageSets symbols;
   C:/Users/gregu/Documents/rsc/rsc/nw/SysTcpSocket.win.cpp(147):    auto list = std::unique_ptr< pollfd[] >(new pollfd[count]);
 W060 Default copy constructor invoked
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(155):    arg_(arg)
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(1975):    attrs_(Numeric::Nil)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(366):       : num_(num), tags_(tags) { CxxStats::Incr(CxxStats::INT_LITERAL); }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(403):       : num_(num), tags_(tags) { CxxStats::Incr(CxxStats::FLOAT_LITERAL); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(370):       : num_(num), tags_(tags) { CxxStats::Incr(CxxStats::INT_LITERAL); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(409):       : num_(num), tags_(tags) { CxxStats::Incr(CxxStats::FLOAT_LITERAL); }
   C:/Users/gregu/Documents/rsc/rsc/pb/PotsProfile.cpp(54):    objAddr_(NilLocalAddress)
   C:/Users/gregu/Documents/rsc/rsc/sb/GlobalAddress.cpp(41): GlobalAddress::GlobalAddress() : sbAddr_(NilLocalAddress)
   C:/Users/gregu/Documents/rsc/rsc/sb/GlobalAddress.cpp(52):    sbAddr_(NilLocalAddress)
@@ -2129,7 +2124,7 @@ W061 Default assignment operator invoked
   C:/Users/gregu/Documents/rsc/rsc/sb/MsgPort.cpp(481):       peer->remAddr_ = locAddr_;
   C:/Users/gregu/Documents/rsc/rsc/st/TestSessions.cpp(419):       addr = GlobalAddress(addr, dest->EnsurePort()->LocAddr().SbAddr());
 W062 Base class constructor is public
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(248):    Class(QualNamePtr& name, Cxx::ClassTag tag);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(251):    Class(QualNamePtr& name, Cxx::ClassTag tag);
   C:/Users/gregu/Documents/rsc/rsc/nb/CfgBoolParm.h(38):    CfgBoolParm(const char* key, const char* def, bool* field, const char* expl);
   C:/Users/gregu/Documents/rsc/rsc/nb/CfgIntParm.h(39):    CfgIntParm(const char* key, const char* def, word* field,
   C:/Users/gregu/Documents/rsc/rsc/nb/CfgStrParm.h(39):    CfgStrParm(const char* key, const char* def,
@@ -2274,15 +2269,15 @@ W077 Virtual function is public
   C:/Users/gregu/Documents/rsc/rsc/cb/ProxyBcSessions.h(509):    virtual void SetUPsm(MediaPsm& psm) override;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(128):    virtual Function* FindFunc(const std::string& name, StackArgVector* args,
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(135):    virtual Function* MatchFunc(const Function* curr, bool base) const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(273):    virtual ClassInst* EnsureInstance(const TypeName* type);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(281):    virtual Class* BaseClass()
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(286):    virtual BaseDecl* GetBaseDecl() const { return base_.get(); }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(303):    virtual Class* GetClassTemplate() const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(318):    virtual bool DerivesFrom(const Class* cls) const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(432):    virtual bool AddAnonymousUnion(const ClassPtr& cls) override;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(449):    virtual void CheckIfUsed(Warning warning) const override;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(457):    virtual Class* DirectClass() const override { return GetClass(); }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(862):    virtual CxxScoped* FindItem(const std::string& name) const override;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(276):    virtual ClassInst* EnsureInstance(const TypeName* type);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(284):    virtual Class* BaseClass()
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(289):    virtual BaseDecl* GetBaseDecl() const { return base_.get(); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(306):    virtual Class* GetClassTemplate() const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(321):    virtual bool DerivesFrom(const Class* cls) const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(435):    virtual bool AddAnonymousUnion(const ClassPtr& cls) override;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(452):    virtual void CheckIfUsed(Warning warning) const override;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(460):    virtual Class* DirectClass() const override { return GetClass(); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(865):    virtual CxxScoped* FindItem(const std::string& name) const override;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.h(115):    virtual void SetScope(CxxScope* scope) override;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.h(240):    virtual CxxToken* GetValue() const = 0;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.h(245):    virtual bool IsDefined() const { return true; }
@@ -2292,11 +2287,11 @@ W077 Virtual function is public
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.h(419):    virtual bool AddElse(const Else* e) { return false; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.h(428):    virtual bool HasCompiledCode() const { return compile_; }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.h(469):    virtual void AddCondition(ExprPtr& c) override { condition_ = std::move(c); }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(64):    virtual bool Display(std::ostream& stream) override;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(76):    virtual bool Display(std::ostream& stream) override;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(92):    virtual bool Display(std::ostream& stream) override;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(108):    virtual bool Display(std::ostream& stream) override;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(128):    virtual bool Display(std::ostream& stream) override;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(64):    virtual bool Display(std::ostream& stream, bool diff) override;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(76):    virtual bool Display(std::ostream& stream, bool diff) override;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(92):    virtual bool Display(std::ostream& stream, bool diff) override;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(108):    virtual bool Display(std::ostream& stream, bool diff) override;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp(128):    virtual bool Display(std::ostream& stream, bool diff) override;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h(114):    virtual void SetLoc(CodeFile* file, size_t pos);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h(127):    virtual void CopyContext(const CxxNamed* that);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h(141):    virtual size_t GetRange(size_t& begin, size_t& end) const;
@@ -2382,39 +2377,39 @@ W077 Virtual function is public
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.h(460):    virtual void CheckAccessControl() const override;
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.h(844):    virtual bool ResolveTemplate
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.h(1227):    virtual bool ResolveTypedef(Typedef* type, size_t n) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(77):    virtual Cxx::ItemType Type() const { return Cxx::Undefined; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(83):    virtual const std::string* Name() const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(87):    virtual QualName* GetQualName() const { return nullptr; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(92):    virtual std::string TypeString(bool arg) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(97):    virtual TypeSpec* GetTypeSpec() const { return nullptr; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(101):    virtual bool IsConst() const { return false; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(105):    virtual bool IsConstPtr() const { return false; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(110):    virtual bool IsAuto() const { return false; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(115):    virtual bool IsIndirect() const { return false; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(119):    virtual bool IsInitializing() const { return false; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(128):    virtual CxxToken* AutoType() const { return nullptr; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(133):    virtual Namespace* GetSpace() const { return nullptr; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(138):    virtual Class* GetClass() const { return nullptr; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(143):    virtual Class* Declarer() const { return GetClass(); }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(149):    virtual TypeName* GetTemplateArgs() const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(154):    virtual Numeric GetNumeric() const { return Numeric::Nil; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(158):    virtual void GetConvertibleTypes(StackArgVector& types) { }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(163):    virtual CxxNamed* Referent() const;
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(169):    virtual void EnterBlock();
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(174):    virtual void ExitBlock() { }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(180):    virtual bool AppendUnary() { return false; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(184):    virtual CxxToken* Back() { return this; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(189):    virtual bool WasRead() { return false; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(201):    virtual bool WasWritten(const StackArg* arg, bool passed);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(206):    virtual bool SetNonConst() { return true; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(211):    virtual void WasMutated(const StackArg* arg) { }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(217):    virtual void RecordUsage() const { }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(222):    virtual void GetUsages(const CodeFile& file, CxxUsageSets& symbols) const { }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(226):    virtual void Check() const { }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(230):    virtual std::string Trace() const { return NodeBase::EMPTY_STR; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(234):    virtual bool InLine() const { return true; }
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(239):    virtual void Print
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(245):    virtual void Shrink() { }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(79):    virtual Cxx::ItemType Type() const { return Cxx::Undefined; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(85):    virtual const std::string* Name() const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(89):    virtual QualName* GetQualName() const { return nullptr; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(94):    virtual std::string TypeString(bool arg) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(99):    virtual TypeSpec* GetTypeSpec() const { return nullptr; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(103):    virtual bool IsConst() const { return false; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(107):    virtual bool IsConstPtr() const { return false; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(112):    virtual bool IsAuto() const { return false; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(117):    virtual bool IsIndirect() const { return false; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(121):    virtual bool IsInitializing() const { return false; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(130):    virtual CxxToken* AutoType() const { return nullptr; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(135):    virtual Namespace* GetSpace() const { return nullptr; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(140):    virtual Class* GetClass() const { return nullptr; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(145):    virtual Class* Declarer() const { return GetClass(); }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(151):    virtual TypeName* GetTemplateArgs() const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(156):    virtual Numeric GetNumeric() const { return Numeric::Nil; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(160):    virtual void GetConvertibleTypes(StackArgVector& types) { }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(165):    virtual CxxNamed* Referent() const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(171):    virtual void EnterBlock();
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(176):    virtual void ExitBlock() { }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(182):    virtual bool AppendUnary() { return false; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(186):    virtual CxxToken* Back() { return this; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(191):    virtual bool WasRead() { return false; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(203):    virtual bool WasWritten(const StackArg* arg, bool passed);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(208):    virtual bool SetNonConst() { return true; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(213):    virtual void WasMutated(const StackArg* arg) { }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(219):    virtual void RecordUsage() const { }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(224):    virtual void GetUsages(const CodeFile& file, CxxUsageSets& symbols) const { }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(228):    virtual void Check() const { }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(232):    virtual std::string Trace() const { return NodeBase::EMPTY_STR; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(236):    virtual bool InLine() const { return true; }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(241):    virtual void Print
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(247):    virtual void Shrink() { }
   C:/Users/gregu/Documents/rsc/rsc/ct/LibrarySet.h(72):    virtual LibSetType GetType() const;
   C:/Users/gregu/Documents/rsc/rsc/ct/LibrarySet.h(78):    virtual NodeBase::word Check(std::ostream* stream, std::string& expl) const;
   C:/Users/gregu/Documents/rsc/rsc/ct/LibrarySet.h(84):    virtual NodeBase::word Count(std::string& result) const;
@@ -2501,7 +2496,7 @@ W077 Virtual function is public
   C:/Users/gregu/Documents/rsc/rsc/nb/Tool.h(56):    virtual const char* Name() const = 0;
   C:/Users/gregu/Documents/rsc/rsc/nb/Tool.h(60):    virtual const char* Expl() const = 0;
   C:/Users/gregu/Documents/rsc/rsc/nb/Tool.h(66):    virtual std::string Status() const;
-  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(77):    virtual bool Display(std::ostream& stream);
+  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(78):    virtual bool Display(std::ostream& stream, bool diff);
   C:/Users/gregu/Documents/rsc/rsc/nw/InputHandler.h(93):    virtual IpBuffer* AllocBuff
   C:/Users/gregu/Documents/rsc/rsc/nw/InputHandler.h(109):    virtual void ReceiveBuff
   C:/Users/gregu/Documents/rsc/rsc/nw/IoThread.h(61):    virtual bool InsertSocket(SysSocket* socket);
@@ -2704,7 +2699,7 @@ W084 Adjacent arguments have the same type
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxString.cpp(58): size_t RfindScopeOperator(const string& name, size_t begin, size_t end);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxString.h(89):    size_t CompareScopes
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxString.h(128):    size_t Replace(std::string& code,
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(620):    Function* FindNewOrDelete(const StackArg& arg, bool del, bool& pod) const;
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(626):    Function* FindNewOrDelete(const StackArg& arg, bool del, bool& pod) const;
   C:/Users/gregu/Documents/rsc/rsc/ct/Editor.h(184):    NodeBase::word InsertNamespaceForward(Iter& iter,
   C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.h(201):    size_t FindClosing(char lhc, char rhc, size_t pos = std::string::npos) const;
   C:/Users/gregu/Documents/rsc/rsc/ct/Library.h(62):    NodeBase::word Import
@@ -2836,7 +2831,7 @@ W092 Function could be const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxSymbols.h(147):    void EraseType(const Typedef* type);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxSymbols.h(148):    void EraseLocal(const CxxScoped* name);
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxSymbols.h(152):    void EraseLocals();
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(174):    virtual void ExitBlock() { }
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(176):    virtual void ExitBlock() { }
   C:/Users/gregu/Documents/rsc/rsc/ct/Library.h(72):    CodeFile* EnsureFile(const std::string& file, CodeDir* dir = nullptr);
   C:/Users/gregu/Documents/rsc/rsc/ct/Library.h(104):    NodeBase::word Assign(const std::string& name,
   C:/Users/gregu/Documents/rsc/rsc/nb/Array.h(124):    bool Replace(size_t index, const T& item)
@@ -2854,7 +2849,7 @@ W092 Function could be const
   C:/Users/gregu/Documents/rsc/rsc/nb/Thread.h(517):    void StackCheck();
   C:/Users/gregu/Documents/rsc/rsc/nb/Thread.h(529):    void SetSignal(signal_t sig);
   C:/Users/gregu/Documents/rsc/rsc/nb/ThreadRegistry.h(112):    void AssociateIds(const Thread& thread);
-  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(113):    virtual void ClaimBlocks() { }
+  C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h(114):    virtual void ClaimBlocks() { }
   C:/Users/gregu/Documents/rsc/rsc/nt/FunctionProfiler.h(77):    FunctionStats* EnsureRecord(fn_name_arg func, size_t count);
   C:/Users/gregu/Documents/rsc/rsc/nw/IpPort.h(162):    virtual IoThread* CreateIoThread();
   C:/Users/gregu/Documents/rsc/rsc/nw/UdpIoThread.h(75):    void ReleaseResources();
@@ -2893,20 +2888,20 @@ W094 Function could be free
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeDir.h(86):    static bool IsCodeFile(const std::string& name);
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.h(247):    static void GenerateReport(std::ostream* stream, const SetOfIds& set);
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeIncrement.cpp(111):    static LibrarySet* Evaluate(CliThread& cli);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(76):       static bool IsSortedByFile
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(81):       static bool IsSortedByWarning
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(94):       static std::string WarningCode(Warning warning);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(78):       static bool IsSortedByFile
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(83):       static bool IsSortedByWarning
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h(96):       static std::string WarningCode(Warning warning);
   C:/Users/gregu/Documents/rsc/rsc/ct/CtModule.h(56):    static bool Register();
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(186):    static Function* FoundFunc
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(586):    static size_t CreateCodeError
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h(589):    static size_t CreateCodeError
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.h(297):    static void ContextFunctionIsNonConst();
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.h(596):    static void Startup(NodeBase::RestartLevel level) { }
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.h(665):    static std::string Location();
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.h(1305):    static TypeMatch MatchTemplate
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.h(1318):    static Function* InstantiateError
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(278):    static void ShrinkExpression(const ExprPtr& expr);
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(472):    static TypeSpecPtr CreateRef();
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(609):    static void PushType(const std::string& name);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(280):    static void ShrinkExpression(const ExprPtr& expr);
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(478):    static TypeSpecPtr CreateRef();
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h(615):    static void PushType(const std::string& name);
   C:/Users/gregu/Documents/rsc/rsc/ct/Editor.h(143):    static Iter Find(SourceList& list, size_t line);
   C:/Users/gregu/Documents/rsc/rsc/ct/Editor.h(148):    static Iter Find(SourceList& list, const std::string& source);
   C:/Users/gregu/Documents/rsc/rsc/ct/Editor.h(206):    static NodeBase::word Report
@@ -2952,7 +2947,7 @@ W094 Function could be free
   C:/Users/gregu/Documents/rsc/rsc/nb/MemoryTrace.h(57):    static const char* TypeString(MemoryType type);
   C:/Users/gregu/Documents/rsc/rsc/nb/ModuleRegistry.h(87):    static RestartLevel NextLevel();
   C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(757):    static word DisplayHelpFile(CliThread& cli, const string& name);
-  C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(1892):    static void SendAckToOutputFile(const CliThread& cli);
+  C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp(1904):    static void SendAckToOutputFile(const CliThread& cli);
   C:/Users/gregu/Documents/rsc/rsc/nb/NbModule.h(60):    static bool Register();
   C:/Users/gregu/Documents/rsc/rsc/nb/NbTracer.h(73):    static TraceRc SelectThread(ThreadId tid, TraceStatus status);
   C:/Users/gregu/Documents/rsc/rsc/nb/NbTracer.h(77):    static bool ThreadsEmpty();
@@ -3353,17 +3348,17 @@ W108 Function does not invoke Debug::ft
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(2148): void CodeFile::InsertType(Typedef* type)
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp(2156): void CodeFile::InsertUsing(Using* use)
   C:/Users/gregu/Documents/rsc/rsc/ct/CodeTypes.cpp(304): bool IsUnusedItemWarning(Warning warning)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(85): word CodeInfo::FindWarning(const WarningLog& log)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(260): void CodeInfo::GetWarnings(const CodeFile* file, WarningLogVector& warnings)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(273): bool CodeInfo::IsSortedByFile(const WarningLog& log1, const WarningLog& log2)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(291): bool CodeInfo::IsSortedByWarning(const WarningLog& log1, const WarningLog& log2)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(97): word CodeInfo::FindWarning(const WarningLog& log)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(272): void CodeInfo::GetWarnings(const CodeFile* file, WarningLogVector& warnings)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(285): bool CodeInfo::IsSortedByFile(const WarningLog& log1, const WarningLog& log2)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp(303): bool CodeInfo::IsSortedByWarning(const WarningLog& log1, const WarningLog& log2)
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(379): void Class::AddItem(CxxNamed* item)
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1230): Class* Class::GetClassTemplate() const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1262): Cxx::Access Class::GetCurrAccess() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1340): size_t Class::GetRange(size_t& begin, size_t& end) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1355): CxxScope* Class::GetTemplate() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1726): Class* Class::OuterClass() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(2457): const FunctionPtrVector* CxxArea::FuncVector(const string& name) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1334): size_t Class::GetRange(size_t& begin, size_t& end) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1349): CxxScope* Class::GetTemplate() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(1720): Class* Class::OuterClass() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp(2451): const FunctionPtrVector* CxxArea::FuncVector(const string& name) const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.cpp(48): void AlignLeft(ostream& stream, const string& prefix)
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.cpp(151): CxxToken* Define::AutoType() const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.cpp(822): CxxScope* MacroName::GetScope() const
@@ -3392,36 +3387,36 @@ W108 Function does not invoke Debug::ft
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(1861): TypeName* QualName::At(size_t n) const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(1971): TypeName* QualName::GetTemplateArgs() const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2033): TypeName* QualName::Last() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2281): size_t QualName::Size() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2559): CxxNamed* TypeName::DirectType() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2583): TypeName* TypeName::GetTemplateArgs() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2720): void TypeName::PushBack(TypeNamePtr& type)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2936): void TypeSpec::AddArray(ArraySpecPtr& array)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2943): void TypeSpec::AdjustPtrs(TagCount count)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2958): TagCount TypeSpec::ArrayCount() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2966): TagCount TypeSpec::Arrays() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2974): TypeSpec* TypeSpec::Clone() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2996): void TypeSpec::EnterArrays() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3003): void TypeSpec::EnteringScope(const CxxScope* scope)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3010): TypeTags TypeSpec::GetTags() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3020): bool TypeSpec::HasArrayDefn() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3028): void TypeSpec::Instantiating() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3035): bool TypeSpec::MatchesExactly(const TypeSpec* that) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3043): TypeMatch TypeSpec::MatchTemplate(TypeSpec* that, stringVector& tmpltParms,
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3052): TypeMatch TypeSpec::MatchTemplateArg(const TypeSpec* that) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3083): TagCount TypeSpec::PtrCount(bool arrays) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3091): TagCount TypeSpec::Ptrs(bool arrays) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3099): TagCount TypeSpec::RefCount() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3107): TagCount TypeSpec::Refs() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3115): void TypeSpec::RemoveRefs()
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3122): StackArg TypeSpec::ResultType() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3130): void TypeSpec::SetArrayPos(int8_t pos)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3137): void TypeSpec::SetConst(bool readonly)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3144): void TypeSpec::SetConstPtr(bool constptr)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3151): void TypeSpec::SetPtrDetached(bool on)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3158): void TypeSpec::SetPtrs(TagCount ptrs)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3165): void TypeSpec::SetRefDetached(bool on)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3174): void TypeSpec::SetRefs(TagCount refs)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2280): size_t QualName::Size() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2558): CxxNamed* TypeName::DirectType() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2582): TypeName* TypeName::GetTemplateArgs() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2719): void TypeName::PushBack(TypeNamePtr& type)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2935): void TypeSpec::AddArray(ArraySpecPtr& array)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2942): void TypeSpec::AdjustPtrs(TagCount count)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2957): TagCount TypeSpec::ArrayCount() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2965): TagCount TypeSpec::Arrays() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2973): TypeSpec* TypeSpec::Clone() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(2995): void TypeSpec::EnterArrays() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3002): void TypeSpec::EnteringScope(const CxxScope* scope)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3009): TypeTags TypeSpec::GetTags() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3019): bool TypeSpec::HasArrayDefn() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3027): void TypeSpec::Instantiating() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3034): bool TypeSpec::MatchesExactly(const TypeSpec* that) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3042): TypeMatch TypeSpec::MatchTemplate(TypeSpec* that, stringVector& tmpltParms,
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3051): TypeMatch TypeSpec::MatchTemplateArg(const TypeSpec* that) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3082): TagCount TypeSpec::PtrCount(bool arrays) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3090): TagCount TypeSpec::Ptrs(bool arrays) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3098): TagCount TypeSpec::RefCount() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3106): TagCount TypeSpec::Refs() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3114): void TypeSpec::RemoveRefs()
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3121): StackArg TypeSpec::ResultType() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3129): void TypeSpec::SetArrayPos(int8_t pos)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3136): void TypeSpec::SetConst(bool readonly)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3143): void TypeSpec::SetConstPtr(bool constptr)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3150): void TypeSpec::SetPtrDetached(bool on)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3157): void TypeSpec::SetPtrs(TagCount ptrs)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3164): void TypeSpec::SetRefDetached(bool on)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp(3173): void TypeSpec::SetRefs(TagCount refs)
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(114): bool Block::CrlfOver(Form form) const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(233): CxxToken* Block::FirstStatement() const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(241): Function* Block::GetFunction() const
@@ -3434,48 +3429,48 @@ W108 Function does not invoke Debug::ft
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(1372): bool Data::IsConst() const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(1380): bool Data::IsConstPtr() const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(1493): bool Data::WasRead()
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3211): FunctionRole Function::FuncRole() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3247): FunctionType Function::FuncType() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3257): CodeFile* Function::GetDeclFile() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3264): const Function* Function::GetDefn() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3273): CodeFile* Function::GetDefnFile() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3282): size_t Function::GetRange(size_t& begin, size_t& end) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3298): CxxScope* Function::GetScope() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3310): CxxScope* Function::GetTemplate() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3322): TemplateType Function::GetTemplateType() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3798): bool Function::IsInTemplateInstance() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4478): void FuncSpec::AddArray(ArraySpecPtr& array)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4485): void FuncSpec::AdjustPtrs(TagCount count)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4499): TagCount FuncSpec::ArrayCount() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4506): TagCount FuncSpec::Arrays() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4513): void FuncSpec::Check() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4520): TypeSpec* FuncSpec::Clone() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4542): void FuncSpec::EnterArrays() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4561): void FuncSpec::FindReferent()
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4569): TypeTags FuncSpec::GetTags() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4576): TypeName* FuncSpec::GetTemplateArgs() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4583): TypeSpec* FuncSpec::GetTypeSpec() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4590): bool FuncSpec::HasArrayDefn() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4597): void FuncSpec::Instantiating() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4605): bool FuncSpec::IsConst() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4612): bool FuncSpec::IsConstPtr() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4619): bool FuncSpec::MatchesExactly(const TypeSpec* that) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4627): TypeMatch FuncSpec::MatchTemplate(TypeSpec* that, stringVector& tmpltParms,
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4637): TypeMatch FuncSpec::MatchTemplateArg(const TypeSpec* that) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4659): TagCount FuncSpec::PtrCount(bool arrays) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4666): TagCount FuncSpec::Ptrs(bool arrays) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4673): TagCount FuncSpec::RefCount() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4680): TagCount FuncSpec::Refs() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4687): void FuncSpec::RemoveRefs()
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4694): StackArg FuncSpec::ResultType() const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4701): void FuncSpec::SetArrayPos(int8_t pos)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4709): void FuncSpec::SetConst(bool readonly)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4717): void FuncSpec::SetConstPtr(bool constptr)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4725): void FuncSpec::SetPtrDetached(bool on)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4733): void FuncSpec::SetPtrs(TagCount ptrs)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4741): void FuncSpec::SetRefDetached(bool on)
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4749): void FuncSpec::SetReferent(CxxNamed* item, const SymbolView* view) const
-  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4757): void FuncSpec::SetRefs(TagCount refs)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3213): FunctionRole Function::FuncRole() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3249): FunctionType Function::FuncType() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3259): CodeFile* Function::GetDeclFile() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3266): const Function* Function::GetDefn() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3275): CodeFile* Function::GetDefnFile() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3284): size_t Function::GetRange(size_t& begin, size_t& end) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3300): CxxScope* Function::GetScope() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3312): CxxScope* Function::GetTemplate() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3324): TemplateType Function::GetTemplateType() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(3802): bool Function::IsInTemplateInstance() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4482): void FuncSpec::AddArray(ArraySpecPtr& array)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4489): void FuncSpec::AdjustPtrs(TagCount count)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4503): TagCount FuncSpec::ArrayCount() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4510): TagCount FuncSpec::Arrays() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4517): void FuncSpec::Check() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4524): TypeSpec* FuncSpec::Clone() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4546): void FuncSpec::EnterArrays() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4565): void FuncSpec::FindReferent()
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4573): TypeTags FuncSpec::GetTags() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4580): TypeName* FuncSpec::GetTemplateArgs() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4587): TypeSpec* FuncSpec::GetTypeSpec() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4594): bool FuncSpec::HasArrayDefn() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4601): void FuncSpec::Instantiating() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4609): bool FuncSpec::IsConst() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4616): bool FuncSpec::IsConstPtr() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4623): bool FuncSpec::MatchesExactly(const TypeSpec* that) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4631): TypeMatch FuncSpec::MatchTemplate(TypeSpec* that, stringVector& tmpltParms,
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4641): TypeMatch FuncSpec::MatchTemplateArg(const TypeSpec* that) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4663): TagCount FuncSpec::PtrCount(bool arrays) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4670): TagCount FuncSpec::Ptrs(bool arrays) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4677): TagCount FuncSpec::RefCount() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4684): TagCount FuncSpec::Refs() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4691): void FuncSpec::RemoveRefs()
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4698): StackArg FuncSpec::ResultType() const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4705): void FuncSpec::SetArrayPos(int8_t pos)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4713): void FuncSpec::SetConst(bool readonly)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4721): void FuncSpec::SetConstPtr(bool constptr)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4729): void FuncSpec::SetPtrDetached(bool on)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4737): void FuncSpec::SetPtrs(TagCount ptrs)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4745): void FuncSpec::SetRefDetached(bool on)
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4753): void FuncSpec::SetReferent(CxxNamed* item, const SymbolView* view) const
+  C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp(4761): void FuncSpec::SetRefs(TagCount refs)
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(297): Class* BaseDecl::GetClass() const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(398): void CxxScoped::AddFiles(SetOfIds& imSet) const
   C:/Users/gregu/Documents/rsc/rsc/ct/CxxScoped.cpp(533): CodeFile* CxxScoped::GetImplFile() const
@@ -4418,12 +4413,8 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CodeFile.cpp
     249:                auto type = static_cast< const Typedef* >(*item2);
     272:          auto type = static_cast< const Typedef* >(*item1);
     521:    affecterIds_ = static_cast< CodeFileSet* >(asSet)->Set();
-    2483:    auto& affecterIds = static_cast< CodeFileSet* >(affecterSet)->Set();
-    2621:       auto base = static_cast< const Class* >(*b);
-  W058 Default constructor invoked: POD members not initialized
-    2345:       WarningLog log;
-  W059 Default constructor invoked
-    2782:    CxxUsageSets symbols;
+    2476:    auto& affecterIds = static_cast< CodeFileSet* >(affecterSet)->Set();
+    2614:       auto base = static_cast< const Class* >(*b);
   W108 Function does not invoke Debug::ft
     1891: void CodeFile::GetLineCounts() const
     1907: LineType CodeFile::GetLineType(size_t n) const
@@ -4463,8 +4454,6 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CodeFileSet.cpp
   W008 Cast removes const qualification
     535:    LibrarySet* nbSet = (LibrarySet*) this;
     567:    LibrarySet* nsSet = (LibrarySet*) this;
-  W058 Default constructor invoked: POD members not initialized
-    848:    FileLevel item;
 C:/Users/gregu/Documents/rsc/rsc/ct/CodeIncrement.cpp
   W045 Member could be protected
     111:    static LibrarySet* Evaluate(CliThread& cli);
@@ -4494,23 +4483,30 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CodeTypes.h
     292:    SymbolView(Accessibility a, TypeMatch m, bool u, bool f, bool r, Distance d);
 C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.cpp
   W005 Functional cast
-    167:       *stream << setw(12) << LineType(t)
-    179:          *stream << setw(6) << WarningCode(Warning(w)) << setw(6)
-    180:             << WarningCounts_[w] << spaces(2) << Warning(w) << CRLF;
+    179:       *stream << setw(12) << LineType(t)
+    191:          *stream << setw(6) << WarningCode(Warning(w)) << setw(6)
+    192:             << WarningCounts_[w] << spaces(2) << Warning(w) << CRLF;
   W108 Function does not invoke Debug::ft
-    85: word CodeInfo::FindWarning(const WarningLog& log)
-    260: void CodeInfo::GetWarnings(const CodeFile* file, WarningLogVector& warnings)
-    273: bool CodeInfo::IsSortedByFile(const WarningLog& log1, const WarningLog& log2)
-    291: bool CodeInfo::IsSortedByWarning(const WarningLog& log1, const WarningLog& log2)
+    97: word CodeInfo::FindWarning(const WarningLog& log)
+    272: void CodeInfo::GetWarnings(const CodeFile* file, WarningLogVector& warnings)
+    285: bool CodeInfo::IsSortedByFile(const WarningLog& log1, const WarningLog& log2)
+    303: bool CodeInfo::IsSortedByWarning(const WarningLog& log1, const WarningLog& log2)
 C:/Users/gregu/Documents/rsc/rsc/ct/CodeWarning.h
   W033 Unused function
-    48:       bool operator!=(const WarningLog& that) const;
+    50:       bool operator!=(const WarningLog& that) const;
   W044 Member could be private
-    76:       static bool IsSortedByFile
+    78:       static bool IsSortedByFile
+  W055 Data could be const
+    42:       size_t line;           // line where warning occurred
+    43:       Warning warning;       // type of warning
+    44:       size_t offset;         // warning-specific; displayed if non-zero
+    45:       std::string info;      // warning-specific
+  W056 Data could be const pointer
+    41:       const CodeFile* file;  // file where warning occurred
   W094 Function could be free
-    76:       static bool IsSortedByFile
-    81:       static bool IsSortedByWarning
-    94:       static std::string WarningCode(Warning warning);
+    78:       static bool IsSortedByFile
+    83:       static bool IsSortedByWarning
+    96:       static std::string WarningCode(Warning warning);
 C:/Users/gregu/Documents/rsc/rsc/ct/CtModule.h
   W049 Data is init-only
     60:    static bool Registered;
@@ -4635,60 +4631,58 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.cpp
     1016:    auto area = static_cast< CxxArea* >(GetScope());
     1019:    if(inst != nullptr) return static_cast< ClassInst* >(inst);
     1036:          auto c = static_cast< Class* >(*s);
-    1960:       auto func = static_cast< const Function* >(item);
-    1986:       auto func = static_cast< const Function* >(item);
+    1954:       auto func = static_cast< const Function* >(item);
+    1980:       auto func = static_cast< const Function* >(item);
   W008 Cast removes const qualification
     1233:    return const_cast< Class* >(this);
-    1358:    return static_cast< CxxScope* >(const_cast< Class* >(this));
-    1956:       return const_cast< ClassInst* >(this);
-  W058 Default constructor invoked: POD members not initialized
-    1322:    DataInitAttrs attrs;
+    1352:    return static_cast< CxxScope* >(const_cast< Class* >(this));
+    1950:       return const_cast< ClassInst* >(this);
   W108 Function does not invoke Debug::ft
     379: void Class::AddItem(CxxNamed* item)
     1230: Class* Class::GetClassTemplate() const
     1262: Cxx::Access Class::GetCurrAccess() const
-    1340: size_t Class::GetRange(size_t& begin, size_t& end) const
-    1355: CxxScope* Class::GetTemplate() const
-    1726: Class* Class::OuterClass() const
-    2457: const FunctionPtrVector* CxxArea::FuncVector(const string& name) const
+    1334: size_t Class::GetRange(size_t& begin, size_t& end) const
+    1349: CxxScope* Class::GetTemplate() const
+    1720: Class* Class::OuterClass() const
+    2451: const FunctionPtrVector* CxxArea::FuncVector(const string& name) const
 C:/Users/gregu/Documents/rsc/rsc/ct/CxxArea.h
   W004 C-style cast
-    441:    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
+    444:    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
   W007 Cast down the inheritance hierarchy
-    838:       const { return static_cast< Namespace* >(GetScope()); }
+    841:       const { return static_cast< Namespace* >(GetScope()); }
   W008 Cast removes const qualification
     144:       override { return const_cast< CxxArea* >(this); }
-    441:    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
-    477:       override { return const_cast< Class* >(this); }
-    875:       override { return const_cast< Namespace* >(this); }
+    444:    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
+    480:       override { return const_cast< Class* >(this); }
+    878:       override { return const_cast< Namespace* >(this); }
   W044 Member could be private
     119:    Typedef* FindType(const std::string& name) const;
     164:    Enum* FindEnum(const std::string& name) const;
     168:    Enumerator* FindEnumerator(const std::string& name) const;
-    362:    Function* FindFuncByRole(FunctionRole role, bool base) const;
-    366:    FunctionDefinition GetFuncDefinition(const Function* func) const;
-    843:    Namespace* FindNamespace(const std::string& name) const;
+    365:    Function* FindFuncByRole(FunctionRole role, bool base) const;
+    369:    FunctionDefinition GetFuncDefinition(const Function* func) const;
+    846:    Namespace* FindNamespace(const std::string& name) const;
   W045 Member could be protected
     79:    const ClassPtrVector* Classes() const { return &classes_; }
     87:    const EnumPtrVector* Enums() const { return &enums_; }
     91:    const ForwardPtrVector* Forws() const { return &forws_; }
   W062 Base class constructor is public
-    248:    Class(QualNamePtr& name, Cxx::ClassTag tag);
+    251:    Class(QualNamePtr& name, Cxx::ClassTag tag);
   W077 Virtual function is public
     128:    virtual Function* FindFunc(const std::string& name, StackArgVector* args,
     135:    virtual Function* MatchFunc(const Function* curr, bool base) const;
-    273:    virtual ClassInst* EnsureInstance(const TypeName* type);
-    281:    virtual Class* BaseClass()
-    286:    virtual BaseDecl* GetBaseDecl() const { return base_.get(); }
-    303:    virtual Class* GetClassTemplate() const;
-    318:    virtual bool DerivesFrom(const Class* cls) const;
-    432:    virtual bool AddAnonymousUnion(const ClassPtr& cls) override;
-    449:    virtual void CheckIfUsed(Warning warning) const override;
-    457:    virtual Class* DirectClass() const override { return GetClass(); }
-    862:    virtual CxxScoped* FindItem(const std::string& name) const override;
+    276:    virtual ClassInst* EnsureInstance(const TypeName* type);
+    284:    virtual Class* BaseClass()
+    289:    virtual BaseDecl* GetBaseDecl() const { return base_.get(); }
+    306:    virtual Class* GetClassTemplate() const;
+    321:    virtual bool DerivesFrom(const Class* cls) const;
+    435:    virtual bool AddAnonymousUnion(const ClassPtr& cls) override;
+    452:    virtual void CheckIfUsed(Warning warning) const override;
+    460:    virtual Class* DirectClass() const override { return GetClass(); }
+    865:    virtual CxxScoped* FindItem(const std::string& name) const override;
   W094 Function could be free
     186:    static Function* FoundFunc
-    586:    static size_t CreateCodeError
+    589:    static size_t CreateCodeError
 C:/Users/gregu/Documents/rsc/rsc/ct/CxxDirective.cpp
   W007 Cast down the inheritance hierarchy
     872:       auto macro = static_cast< Macro* >(ref_);
@@ -4725,11 +4719,11 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CxxExecute.cpp
   W060 Default copy constructor invoked
     155:    arg_(arg)
   W077 Virtual function is public
-    64:    virtual bool Display(std::ostream& stream) override;
-    76:    virtual bool Display(std::ostream& stream) override;
-    92:    virtual bool Display(std::ostream& stream) override;
-    108:    virtual bool Display(std::ostream& stream) override;
-    128:    virtual bool Display(std::ostream& stream) override;
+    64:    virtual bool Display(std::ostream& stream, bool diff) override;
+    76:    virtual bool Display(std::ostream& stream, bool diff) override;
+    92:    virtual bool Display(std::ostream& stream, bool diff) override;
+    108:    virtual bool Display(std::ostream& stream, bool diff) override;
+    128:    virtual bool Display(std::ostream& stream, bool diff) override;
   W108 Function does not invoke Debug::ft
     190: const Parser* Context::GetParser()
     240: bool Context::OptionIsOn(char opt)
@@ -4779,7 +4773,7 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp
   W008 Cast removes const qualification
     1029:    return const_cast< DataSpec* >(this);
     1422:    const_cast< DataSpec* >(this)->FindReferent();
-    2586:    return const_cast< TypeName* >(this);
+    2585:    return const_cast< TypeName* >(this);
   W108 Function does not invoke Debug::ft
     177: CxxArea* CxxNamed::GetArea() const
     186: Class* CxxNamed::GetClass() const
@@ -4795,36 +4789,36 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.cpp
     1861: TypeName* QualName::At(size_t n) const
     1971: TypeName* QualName::GetTemplateArgs() const
     2033: TypeName* QualName::Last() const
-    2281: size_t QualName::Size() const
-    2559: CxxNamed* TypeName::DirectType() const
-    2583: TypeName* TypeName::GetTemplateArgs() const
-    2720: void TypeName::PushBack(TypeNamePtr& type)
-    2936: void TypeSpec::AddArray(ArraySpecPtr& array)
-    2943: void TypeSpec::AdjustPtrs(TagCount count)
-    2958: TagCount TypeSpec::ArrayCount() const
-    2966: TagCount TypeSpec::Arrays() const
-    2974: TypeSpec* TypeSpec::Clone() const
-    2996: void TypeSpec::EnterArrays() const
-    3003: void TypeSpec::EnteringScope(const CxxScope* scope)
-    3010: TypeTags TypeSpec::GetTags() const
-    3020: bool TypeSpec::HasArrayDefn() const
-    3028: void TypeSpec::Instantiating() const
-    3035: bool TypeSpec::MatchesExactly(const TypeSpec* that) const
-    3043: TypeMatch TypeSpec::MatchTemplate(TypeSpec* that, stringVector& tmpltParms,
-    3052: TypeMatch TypeSpec::MatchTemplateArg(const TypeSpec* that) const
-    3083: TagCount TypeSpec::PtrCount(bool arrays) const
-    3091: TagCount TypeSpec::Ptrs(bool arrays) const
-    3099: TagCount TypeSpec::RefCount() const
-    3107: TagCount TypeSpec::Refs() const
-    3115: void TypeSpec::RemoveRefs()
-    3122: StackArg TypeSpec::ResultType() const
-    3130: void TypeSpec::SetArrayPos(int8_t pos)
-    3137: void TypeSpec::SetConst(bool readonly)
-    3144: void TypeSpec::SetConstPtr(bool constptr)
-    3151: void TypeSpec::SetPtrDetached(bool on)
-    3158: void TypeSpec::SetPtrs(TagCount ptrs)
-    3165: void TypeSpec::SetRefDetached(bool on)
-    3174: void TypeSpec::SetRefs(TagCount refs)
+    2280: size_t QualName::Size() const
+    2558: CxxNamed* TypeName::DirectType() const
+    2582: TypeName* TypeName::GetTemplateArgs() const
+    2719: void TypeName::PushBack(TypeNamePtr& type)
+    2935: void TypeSpec::AddArray(ArraySpecPtr& array)
+    2942: void TypeSpec::AdjustPtrs(TagCount count)
+    2957: TagCount TypeSpec::ArrayCount() const
+    2965: TagCount TypeSpec::Arrays() const
+    2973: TypeSpec* TypeSpec::Clone() const
+    2995: void TypeSpec::EnterArrays() const
+    3002: void TypeSpec::EnteringScope(const CxxScope* scope)
+    3009: TypeTags TypeSpec::GetTags() const
+    3019: bool TypeSpec::HasArrayDefn() const
+    3027: void TypeSpec::Instantiating() const
+    3034: bool TypeSpec::MatchesExactly(const TypeSpec* that) const
+    3042: TypeMatch TypeSpec::MatchTemplate(TypeSpec* that, stringVector& tmpltParms,
+    3051: TypeMatch TypeSpec::MatchTemplateArg(const TypeSpec* that) const
+    3082: TagCount TypeSpec::PtrCount(bool arrays) const
+    3090: TagCount TypeSpec::Ptrs(bool arrays) const
+    3098: TagCount TypeSpec::RefCount() const
+    3106: TagCount TypeSpec::Refs() const
+    3114: void TypeSpec::RemoveRefs()
+    3121: StackArg TypeSpec::ResultType() const
+    3129: void TypeSpec::SetArrayPos(int8_t pos)
+    3136: void TypeSpec::SetConst(bool readonly)
+    3143: void TypeSpec::SetConstPtr(bool constptr)
+    3150: void TypeSpec::SetPtrDetached(bool on)
+    3157: void TypeSpec::SetPtrs(TagCount ptrs)
+    3164: void TypeSpec::SetRefDetached(bool on)
+    3173: void TypeSpec::SetRefs(TagCount refs)
 C:/Users/gregu/Documents/rsc/rsc/ct/CxxNamed.h
   W004 C-style cast
     1169:    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
@@ -4932,18 +4926,16 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp
     1344:          auto op = static_cast< Operation* >(expr);
     1638:       if(anon) StackArg::SetAutoTypeFor(static_cast< FuncData& >(*next_));
     1684:    auto data = static_cast< FuncData* >(next_.get());
-    2561:       if(!static_cast< Function* >(item)->virtual_)
-    2962:             static_cast< ClassData* >(data)->SetInit(m->get());
-    3173:    return static_cast< Function* >((*cti)->FindInstanceAnalog(this));
-    4456:       auto func = static_cast< ClassInst* >(cls)->FindTemplateAnalog(this);
-    4457:       if(func != nullptr) ++static_cast< Function* >(func)->calls_;
+    2563:       if(!static_cast< Function* >(item)->virtual_)
+    2964:             static_cast< ClassData* >(data)->SetInit(m->get());
+    3175:    return static_cast< Function* >((*cti)->FindInstanceAnalog(this));
+    4460:       auto func = static_cast< ClassInst* >(cls)->FindTemplateAnalog(this);
+    4461:       if(func != nullptr) ++static_cast< Function* >(func)->calls_;
   W008 Cast removes const qualification
     2108:    return FoundFunc(const_cast< Function* >(this), args, match);
-    3137:    auto prev = const_cast< Function* >(this);
-    3314:       (const_cast< Function* >(this));
-    3568:    func->SetTemplate(const_cast< Function* >(this));
-  W059 Default constructor invoked
-    3353:    CxxUsageSets usages;
+    3139:    auto prev = const_cast< Function* >(this);
+    3316:       (const_cast< Function* >(this));
+    3570:    func->SetTemplate(const_cast< Function* >(this));
   W108 Function does not invoke Debug::ft
     114: bool Block::CrlfOver(Form form) const
     233: CxxToken* Block::FirstStatement() const
@@ -4957,48 +4949,48 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.cpp
     1372: bool Data::IsConst() const
     1380: bool Data::IsConstPtr() const
     1493: bool Data::WasRead()
-    3211: FunctionRole Function::FuncRole() const
-    3247: FunctionType Function::FuncType() const
-    3257: CodeFile* Function::GetDeclFile() const
-    3264: const Function* Function::GetDefn() const
-    3273: CodeFile* Function::GetDefnFile() const
-    3282: size_t Function::GetRange(size_t& begin, size_t& end) const
-    3298: CxxScope* Function::GetScope() const
-    3310: CxxScope* Function::GetTemplate() const
-    3322: TemplateType Function::GetTemplateType() const
-    3798: bool Function::IsInTemplateInstance() const
-    4478: void FuncSpec::AddArray(ArraySpecPtr& array)
-    4485: void FuncSpec::AdjustPtrs(TagCount count)
-    4499: TagCount FuncSpec::ArrayCount() const
-    4506: TagCount FuncSpec::Arrays() const
-    4513: void FuncSpec::Check() const
-    4520: TypeSpec* FuncSpec::Clone() const
-    4542: void FuncSpec::EnterArrays() const
-    4561: void FuncSpec::FindReferent()
-    4569: TypeTags FuncSpec::GetTags() const
-    4576: TypeName* FuncSpec::GetTemplateArgs() const
-    4583: TypeSpec* FuncSpec::GetTypeSpec() const
-    4590: bool FuncSpec::HasArrayDefn() const
-    4597: void FuncSpec::Instantiating() const
-    4605: bool FuncSpec::IsConst() const
-    4612: bool FuncSpec::IsConstPtr() const
-    4619: bool FuncSpec::MatchesExactly(const TypeSpec* that) const
-    4627: TypeMatch FuncSpec::MatchTemplate(TypeSpec* that, stringVector& tmpltParms,
-    4637: TypeMatch FuncSpec::MatchTemplateArg(const TypeSpec* that) const
-    4659: TagCount FuncSpec::PtrCount(bool arrays) const
-    4666: TagCount FuncSpec::Ptrs(bool arrays) const
-    4673: TagCount FuncSpec::RefCount() const
-    4680: TagCount FuncSpec::Refs() const
-    4687: void FuncSpec::RemoveRefs()
-    4694: StackArg FuncSpec::ResultType() const
-    4701: void FuncSpec::SetArrayPos(int8_t pos)
-    4709: void FuncSpec::SetConst(bool readonly)
-    4717: void FuncSpec::SetConstPtr(bool constptr)
-    4725: void FuncSpec::SetPtrDetached(bool on)
-    4733: void FuncSpec::SetPtrs(TagCount ptrs)
-    4741: void FuncSpec::SetRefDetached(bool on)
-    4749: void FuncSpec::SetReferent(CxxNamed* item, const SymbolView* view) const
-    4757: void FuncSpec::SetRefs(TagCount refs)
+    3213: FunctionRole Function::FuncRole() const
+    3249: FunctionType Function::FuncType() const
+    3259: CodeFile* Function::GetDeclFile() const
+    3266: const Function* Function::GetDefn() const
+    3275: CodeFile* Function::GetDefnFile() const
+    3284: size_t Function::GetRange(size_t& begin, size_t& end) const
+    3300: CxxScope* Function::GetScope() const
+    3312: CxxScope* Function::GetTemplate() const
+    3324: TemplateType Function::GetTemplateType() const
+    3802: bool Function::IsInTemplateInstance() const
+    4482: void FuncSpec::AddArray(ArraySpecPtr& array)
+    4489: void FuncSpec::AdjustPtrs(TagCount count)
+    4503: TagCount FuncSpec::ArrayCount() const
+    4510: TagCount FuncSpec::Arrays() const
+    4517: void FuncSpec::Check() const
+    4524: TypeSpec* FuncSpec::Clone() const
+    4546: void FuncSpec::EnterArrays() const
+    4565: void FuncSpec::FindReferent()
+    4573: TypeTags FuncSpec::GetTags() const
+    4580: TypeName* FuncSpec::GetTemplateArgs() const
+    4587: TypeSpec* FuncSpec::GetTypeSpec() const
+    4594: bool FuncSpec::HasArrayDefn() const
+    4601: void FuncSpec::Instantiating() const
+    4609: bool FuncSpec::IsConst() const
+    4616: bool FuncSpec::IsConstPtr() const
+    4623: bool FuncSpec::MatchesExactly(const TypeSpec* that) const
+    4631: TypeMatch FuncSpec::MatchTemplate(TypeSpec* that, stringVector& tmpltParms,
+    4641: TypeMatch FuncSpec::MatchTemplateArg(const TypeSpec* that) const
+    4663: TagCount FuncSpec::PtrCount(bool arrays) const
+    4670: TagCount FuncSpec::Ptrs(bool arrays) const
+    4677: TagCount FuncSpec::RefCount() const
+    4684: TagCount FuncSpec::Refs() const
+    4691: void FuncSpec::RemoveRefs()
+    4698: StackArg FuncSpec::ResultType() const
+    4705: void FuncSpec::SetArrayPos(int8_t pos)
+    4713: void FuncSpec::SetConst(bool readonly)
+    4721: void FuncSpec::SetConstPtr(bool constptr)
+    4729: void FuncSpec::SetPtrDetached(bool on)
+    4737: void FuncSpec::SetPtrs(TagCount ptrs)
+    4745: void FuncSpec::SetRefDetached(bool on)
+    4753: void FuncSpec::SetReferent(CxxNamed* item, const SymbolView* view) const
+    4761: void FuncSpec::SetRefs(TagCount refs)
 C:/Users/gregu/Documents/rsc/rsc/ct/CxxScope.h
   W004 C-style cast
     333:    virtual CxxToken* AutoType() const override { return (CxxToken*) this; }
@@ -5232,59 +5224,57 @@ C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.cpp
     2652: CxxNamed* StrLiteral::Referent() const
 C:/Users/gregu/Documents/rsc/rsc/ct/CxxToken.h
   W008 Cast removes const qualification
-    284:    virtual CxxToken* RootType() const { return const_cast< CxxToken* >(this); }
+    286:    virtual CxxToken* RootType() const { return const_cast< CxxToken* >(this); }
   W060 Default copy constructor invoked
-    366:       : num_(num), tags_(tags) { CxxStats::Incr(CxxStats::INT_LITERAL); }
-    403:       : num_(num), tags_(tags) { CxxStats::Incr(CxxStats::FLOAT_LITERAL); }
+    370:       : num_(num), tags_(tags) { CxxStats::Incr(CxxStats::INT_LITERAL); }
+    409:       : num_(num), tags_(tags) { CxxStats::Incr(CxxStats::FLOAT_LITERAL); }
   W077 Virtual function is public
-    77:    virtual Cxx::ItemType Type() const { return Cxx::Undefined; }
-    83:    virtual const std::string* Name() const;
-    87:    virtual QualName* GetQualName() const { return nullptr; }
-    92:    virtual std::string TypeString(bool arg) const
-    97:    virtual TypeSpec* GetTypeSpec() const { return nullptr; }
-    101:    virtual bool IsConst() const { return false; }
-    105:    virtual bool IsConstPtr() const { return false; }
-    110:    virtual bool IsAuto() const { return false; }
-    115:    virtual bool IsIndirect() const { return false; }
-    119:    virtual bool IsInitializing() const { return false; }
-    128:    virtual CxxToken* AutoType() const { return nullptr; }
-    133:    virtual Namespace* GetSpace() const { return nullptr; }
-    138:    virtual Class* GetClass() const { return nullptr; }
-    143:    virtual Class* Declarer() const { return GetClass(); }
-    149:    virtual TypeName* GetTemplateArgs() const;
-    154:    virtual Numeric GetNumeric() const { return Numeric::Nil; }
-    158:    virtual void GetConvertibleTypes(StackArgVector& types) { }
-    163:    virtual CxxNamed* Referent() const;
-    169:    virtual void EnterBlock();
-    174:    virtual void ExitBlock() { }
-    180:    virtual bool AppendUnary() { return false; }
-    184:    virtual CxxToken* Back() { return this; }
-    189:    virtual bool WasRead() { return false; }
-    201:    virtual bool WasWritten(const StackArg* arg, bool passed);
-    206:    virtual bool SetNonConst() { return true; }
-    211:    virtual void WasMutated(const StackArg* arg) { }
-    217:    virtual void RecordUsage() const { }
-    222:    virtual void GetUsages(const CodeFile& file, CxxUsageSets& symbols) const { }
-    226:    virtual void Check() const { }
-    230:    virtual std::string Trace() const { return NodeBase::EMPTY_STR; }
-    234:    virtual bool InLine() const { return true; }
-    239:    virtual void Print
-    245:    virtual void Shrink() { }
+    79:    virtual Cxx::ItemType Type() const { return Cxx::Undefined; }
+    85:    virtual const std::string* Name() const;
+    89:    virtual QualName* GetQualName() const { return nullptr; }
+    94:    virtual std::string TypeString(bool arg) const
+    99:    virtual TypeSpec* GetTypeSpec() const { return nullptr; }
+    103:    virtual bool IsConst() const { return false; }
+    107:    virtual bool IsConstPtr() const { return false; }
+    112:    virtual bool IsAuto() const { return false; }
+    117:    virtual bool IsIndirect() const { return false; }
+    121:    virtual bool IsInitializing() const { return false; }
+    130:    virtual CxxToken* AutoType() const { return nullptr; }
+    135:    virtual Namespace* GetSpace() const { return nullptr; }
+    140:    virtual Class* GetClass() const { return nullptr; }
+    145:    virtual Class* Declarer() const { return GetClass(); }
+    151:    virtual TypeName* GetTemplateArgs() const;
+    156:    virtual Numeric GetNumeric() const { return Numeric::Nil; }
+    160:    virtual void GetConvertibleTypes(StackArgVector& types) { }
+    165:    virtual CxxNamed* Referent() const;
+    171:    virtual void EnterBlock();
+    176:    virtual void ExitBlock() { }
+    182:    virtual bool AppendUnary() { return false; }
+    186:    virtual CxxToken* Back() { return this; }
+    191:    virtual bool WasRead() { return false; }
+    203:    virtual bool WasWritten(const StackArg* arg, bool passed);
+    208:    virtual bool SetNonConst() { return true; }
+    213:    virtual void WasMutated(const StackArg* arg) { }
+    219:    virtual void RecordUsage() const { }
+    224:    virtual void GetUsages(const CodeFile& file, CxxUsageSets& symbols) const { }
+    228:    virtual void Check() const { }
+    232:    virtual std::string Trace() const { return NodeBase::EMPTY_STR; }
+    236:    virtual bool InLine() const { return true; }
+    241:    virtual void Print
+    247:    virtual void Shrink() { }
   W084 Adjacent arguments have the same type
-    620:    Function* FindNewOrDelete(const StackArg& arg, bool del, bool& pod) const;
+    626:    Function* FindNewOrDelete(const StackArg& arg, bool del, bool& pod) const;
   W092 Function could be const
-    174:    virtual void ExitBlock() { }
+    176:    virtual void ExitBlock() { }
   W094 Function could be free
-    278:    static void ShrinkExpression(const ExprPtr& expr);
-    472:    static TypeSpecPtr CreateRef();
-    609:    static void PushType(const std::string& name);
+    280:    static void ShrinkExpression(const ExprPtr& expr);
+    478:    static TypeSpecPtr CreateRef();
+    615:    static void PushType(const std::string& name);
 C:/Users/gregu/Documents/rsc/rsc/ct/Editor.cpp
   W007 Cast down the inheritance hierarchy
     644:          (const_cast< CxxNamed* >(ref))->OuterSpace();
   W008 Cast removes const qualification
     644:          (const_cast< CxxNamed* >(ref))->OuterSpace();
-  W059 Default constructor invoked
-    363:    CxxUsageSets symbols;
   W108 Function does not invoke Debug::ft
     333: Editor::Iter Editor::Find(SourceList& list, size_t line)
     345: Editor::Iter Editor::Find(SourceList& list, const string& source)
@@ -5327,16 +5317,12 @@ C:/Users/gregu/Documents/rsc/rsc/ct/Interpreter.h
     44: class Interpreter : public NodeBase::Temporary
 C:/Users/gregu/Documents/rsc/rsc/ct/Lexer.cpp
   W005 Functional cast
-    932:          oper = Cxx::Operator(match->second);
+    923:          oper = Cxx::Operator(match->second);
   W007 Cast down the inheritance hierarchy
-    1604:          auto def = static_cast< Define* >(item);
-    1608:             auto code = const_cast< string* >(source_);
+    1595:          auto def = static_cast< Define* >(item);
+    1599:             auto code = const_cast< string* >(source_);
   W008 Cast removes const qualification
-    1608:             auto code = const_cast< string* >(source_);
-  W058 Default constructor invoked: POD members not initialized
-    759:       IntLiteral::Tags tags;
-    806:       FloatLiteral::Tags tags;
-    870:    IntLiteral::Tags tags;
+    1599:             auto code = const_cast< string* >(source_);
   W108 Function does not invoke Debug::ft
     618: size_t Lexer::GetLineNum(size_t pos) const
     642: size_t Lexer::GetLineStart(size_t line) const
@@ -6085,16 +6071,16 @@ C:/Users/gregu/Documents/rsc/rsc/nb/FunctionName.h
     61:    size_t find(fn_name_arg func, const char* str);
 C:/Users/gregu/Documents/rsc/rsc/nb/FunctionTrace.cpp
   W004 C-style cast
-    386:          auto src = (ptr_t) this;
+    391:          auto src = (ptr_t) this;
   W007 Cast down the inheritance hierarchy
     91:       auto curr = static_cast< FunctionTrace* >(rec);
     125:       auto curr = static_cast< FunctionTrace* >(rec);
     189:                   auto last = static_cast< const FunctionTrace* >(rec);
-    261:       auto curr = static_cast< FunctionTrace* >(rec);
-    300:          curr = static_cast< FunctionTrace* >(rec);
-    368:       curr = static_cast< FunctionTrace* >(rec);
-    421:          auto curr = static_cast< FunctionTrace* >(rec);
-    486:          auto curr = static_cast< FunctionTrace* >(rec);
+    266:       auto curr = static_cast< FunctionTrace* >(rec);
+    305:          curr = static_cast< FunctionTrace* >(rec);
+    373:       curr = static_cast< FunctionTrace* >(rec);
+    426:          auto curr = static_cast< FunctionTrace* >(rec);
+    491:          auto curr = static_cast< FunctionTrace* >(rec);
 C:/Users/gregu/Documents/rsc/rsc/nb/Immutable.h
   W033 Unused function
     55:    static void* operator new[](size_t size);
@@ -6202,14 +6188,14 @@ C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.cpp
     484:       rc = nbt->SelectFaction(Faction(id), TraceDefault);
     692:       rc = nbt->SelectFaction(Faction(id), TraceExcluded);
     1089:       rc = nbt->SelectFaction(Faction(id), TraceIncluded);
-    2440:       auto heap = Memory::Heap(MemoryType(m));
+    2452:       auto heap = Memory::Heap(MemoryType(m));
   W044 Member could be private
-    1892:    static void SendAckToOutputFile(const CliThread& cli);
+    1904:    static void SendAckToOutputFile(const CliThread& cli);
   W049 Data is init-only
-    1696:    FunctionGuard guard(FunctionGuard::MakePreemptable, yield);
+    1708:    FunctionGuard guard(FunctionGuard::MakePreemptable, yield);
   W094 Function could be free
     757:    static word DisplayHelpFile(CliThread& cli, const string& name);
-    1892:    static void SendAckToOutputFile(const CliThread& cli);
+    1904:    static void SendAckToOutputFile(const CliThread& cli);
 C:/Users/gregu/Documents/rsc/rsc/nb/NbIncrement.h
   W028 Unused data
     153:    static const id_t LastNbIndex     = 3;
@@ -6508,8 +6494,6 @@ C:/Users/gregu/Documents/rsc/rsc/nb/Singleton.h
   W101 Line contains adjacent spaces
     126:       Singleton_Destroy()  { return "Singleton.Destroy"; }
 C:/Users/gregu/Documents/rsc/rsc/nb/Singletons.cpp
-  W058 Default constructor invoked: POD members not initialized
-    92:    SingletonTuple entry;
   W108 Function does not invoke Debug::ft
     125: Singletons* Singletons::Instance()
 C:/Users/gregu/Documents/rsc/rsc/nb/SoftwareException.h
@@ -6928,18 +6912,18 @@ C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.cpp
     38:    size_(int16_t(size)),
 C:/Users/gregu/Documents/rsc/rsc/nb/TraceRecord.h
   W033 Unused function
-    96:    static void operator delete(void* addr, void* where) { }
+    97:    static void operator delete(void* addr, void* where) { }
   W044 Member could be private
-    87:    static void operator delete(void* addr) { }
-    91:    static void* operator new(size_t size, void* where);
+    88:    static void operator delete(void* addr) { }
+    92:    static void* operator new(size_t size, void* where);
   W045 Member could be protected
     70:    void Nullify() { owner_ = NIL_ID; }
   W052 Data is not private
-    133:    Id rid_ : 8;
+    134:    Id rid_ : 8;
   W077 Virtual function is public
-    77:    virtual bool Display(std::ostream& stream);
+    78:    virtual bool Display(std::ostream& stream, bool diff);
   W092 Function could be const
-    113:    virtual void ClaimBlocks() { }
+    114:    virtual void ClaimBlocks() { }
 C:/Users/gregu/Documents/rsc/rsc/nt/FunctionProfiler.cpp
   W004 C-style cast
     60:    functionq_ = (Q2Way< FunctionStats >*) Memory::Alloc(size, MemTemp);

--- a/output/rsc.trim.txt
+++ b/output/rsc.trim.txt
@@ -248,6 +248,7 @@ LibraryTypes.h
       std::vector [vector]
    Indirect usage:
       NodeBase::id_t [SysTypes.h]
+      size_t [cstddef]
 Editor.h
    Direct usage:
       NodeBase::istreamPtr [SysFile.h]
@@ -7622,6 +7623,7 @@ FunctionTrace.cpp
       NodeBase::ptr_t [SysTypes.h]
       NodeBase::ptrdiff [Algorithms.h]
       NodeBase::ticks_t [Clock.h]
+      NodeBase::usecs_t [Clock.h]
       size_t [cstddef]
       std::basic_ostream [ostream]
       std::basic_string [string]
@@ -10572,6 +10574,7 @@ CodeWarning.cpp
       CodeTools::WarningLog [CodeWarning.h]
       CodeTools::WarningLog::DisplayCode [CodeWarning.h]
       CodeTools::WarningLog::DisplayInfo [CodeWarning.h]
+      CodeTools::WarningLog::WarningLog [CodeWarning.h]
       CodeTools::WarningLog::file [CodeWarning.h]
       CodeTools::WarningLog::info [CodeWarning.h]
       CodeTools::WarningLog::line [CodeWarning.h]
@@ -11097,9 +11100,6 @@ CxxArea.cpp
       CodeTools::Data::IsDefaultConstructible [CxxScope.h]
       CodeTools::Data::Promote [CxxScope.h]
       CodeTools::DataInitAttrs [CxxArea.h]
-      CodeTools::DataInitAttrs::initNeeded [CxxArea.h]
-      CodeTools::DataInitAttrs::initOrder [CxxArea.h]
-      CodeTools::DataInitAttrs::member [CxxArea.h]
       CodeTools::DataPtr [CxxFwd.h]
       CodeTools::DisplayObjects [CodeTypes.h]
       CodeTools::Distance [CodeTypes.h]
@@ -14777,9 +14777,6 @@ Lexer.cpp
       CodeTools::IntLiteral::Size::SIZE_L [CxxToken.h]
       CodeTools::IntLiteral::Size::SIZE_LL [CxxToken.h]
       CodeTools::IntLiteral::Tags [CxxToken.h]
-      CodeTools::IntLiteral::Tags::radix_ [CxxToken.h]
-      CodeTools::IntLiteral::Tags::size_ [CxxToken.h]
-      CodeTools::IntLiteral::Tags::unsigned_ [CxxToken.h]
       CodeTools::LONG_STR [CodeTypes.h]
       CodeTools::Lexer [Lexer.h]
       CodeTools::Lexer::Advance [Lexer.h]

--- a/pb/PotsFeature.h
+++ b/pb/PotsFeature.h
@@ -113,8 +113,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   PotsFeature(const PotsFeature& that);
-   PotsFeature& operator=(const PotsFeature& that);
+   PotsFeature(const PotsFeature& that) = delete;
+   PotsFeature& operator=(const PotsFeature& that) = delete;
 
    //  Returns the parameters used to provision the feature.
    //

--- a/pb/PotsFeatureProfile.h
+++ b/pb/PotsFeatureProfile.h
@@ -77,8 +77,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   PotsFeatureProfile(const PotsFeatureProfile& that);
-   PotsFeatureProfile& operator=(const PotsFeatureProfile& that);
+   PotsFeatureProfile(const PotsFeatureProfile& that) = delete;
+   PotsFeatureProfile& operator=(const PotsFeatureProfile& that) = delete;
 
    //  Deletes the user's subscription to the feature.  Deletion is actually
    //  performed by PotsProfile.Unsubscribe (see below), which also invokes

--- a/pb/PotsProfile.h
+++ b/pb/PotsProfile.h
@@ -153,8 +153,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   PotsProfile(const PotsProfile& that);
-   PotsProfile& operator=(const PotsProfile& that);
+   PotsProfile(const PotsProfile& that) = delete;
+   PotsProfile& operator=(const PotsProfile& that) = delete;
 
    //  The profile's directory number.
    //

--- a/pb/PotsProtocol.h
+++ b/pb/PotsProtocol.h
@@ -226,9 +226,9 @@ public:
    //
    virtual ~Facility() { }
 private:
-   //  Private because this class is not intended to be instantiated.
+   //  Deleted because this class is not intended to be instantiated.
    //
-   Facility();
+   Facility() = delete;
 };
 
 //------------------------------------------------------------------------------

--- a/sb/Factory.h
+++ b/sb/Factory.h
@@ -233,8 +233,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   Factory(const Factory& that);
-   Factory& operator=(const Factory& that);
+   Factory(const Factory& that) = delete;
+   Factory& operator=(const Factory& that) = delete;
 
    //  Allocates an incoming message to wrap BUFF and returns it in MSG.
    //  Returning nullptr indicates that BUFF should be discarded, either

--- a/sb/Initiator.h
+++ b/sb/Initiator.h
@@ -94,8 +94,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   Initiator(const Initiator& that);
-   Initiator& operator=(const Initiator& that);
+   Initiator(const Initiator& that) = delete;
+   Initiator& operator=(const Initiator& that) = delete;
 
    //  The initiator's event handler, which receives either an SAP or SNP,
    //  depending on the trigger with which it has registered.  It can either

--- a/sb/InvokerPool.cpp
+++ b/sb/InvokerPool.cpp
@@ -101,8 +101,8 @@ public:
 private:
    //  Deleted to prohibit copying.
    //
-   InvokerWork(const InvokerWork& that);
-   InvokerWork& operator=(const InvokerWork& that);
+   InvokerWork(const InvokerWork& that) = delete;
+   InvokerWork& operator=(const InvokerWork& that) = delete;
 };
 
 //------------------------------------------------------------------------------

--- a/sb/InvokerPool.h
+++ b/sb/InvokerPool.h
@@ -205,8 +205,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   InvokerPool(const InvokerPool& that);
-   InvokerPool& operator=(const InvokerPool& that);
+   InvokerPool(const InvokerPool& that) = delete;
+   InvokerPool& operator=(const InvokerPool& that) = delete;
 
    //  The scheduler faction in which the pool's invokers run.
    //

--- a/sb/Parameter.h
+++ b/sb/Parameter.h
@@ -179,8 +179,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   Parameter(const Parameter& that);
-   Parameter& operator=(const Parameter& that);
+   Parameter(const Parameter& that) = delete;
+   Parameter& operator=(const Parameter& that) = delete;
 
    //  The protocol to which the parameter belongs.
    //

--- a/sb/Protocol.h
+++ b/sb/Protocol.h
@@ -137,8 +137,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   Protocol(const Protocol& that);
-   Protocol& operator=(const Protocol& that);
+   Protocol(const Protocol& that) = delete;
+   Protocol& operator=(const Protocol& that) = delete;
 
    //  Adds SIGNAL to the protocol.  Invoked by Signal's base class
    //  constructor.

--- a/sb/SbTrace.cpp
+++ b/sb/SbTrace.cpp
@@ -116,9 +116,9 @@ TransTrace::TransTrace
 
 //------------------------------------------------------------------------------
 
-bool TransTrace::Display(ostream& stream)
+bool TransTrace::Display(ostream& stream, bool diff)
 {
-   if(!TimedRecord::Display(stream)) return false;
+   if(!TimedRecord::Display(stream, diff)) return false;
 
    auto delta = ticks1_ - ticks0_;
    auto usecs = Clock::TicksToUsecs(delta);
@@ -283,9 +283,9 @@ void BuffTrace::ClaimBlocks()
 
 //------------------------------------------------------------------------------
 
-bool BuffTrace::Display(ostream& stream)
+bool BuffTrace::Display(ostream& stream, bool diff)
 {
-   if(!TimedRecord::Display(stream)) return false;
+   if(!TimedRecord::Display(stream, diff)) return false;
 
    stream << CRLF;
    stream << string(80, '-') << CRLF;
@@ -445,9 +445,9 @@ SboTrace::SboTrace(size_t size, const Pooled& sbo) :
 
 //------------------------------------------------------------------------------
 
-bool SboTrace::Display(ostream& stream)
+bool SboTrace::Display(ostream& stream, bool diff)
 {
-   if(!TimedRecord::Display(stream)) return false;
+   if(!TimedRecord::Display(stream, diff)) return false;
 
    stream << spaces(TraceDump::EvtToObj) << sbo_ << TraceDump::Tab();
    return true;
@@ -478,9 +478,9 @@ SsmTrace::SsmTrace(Id rid, const ServiceSM& ssm) :
 
 //------------------------------------------------------------------------------
 
-bool SsmTrace::Display(ostream& stream)
+bool SsmTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    auto reg = Singleton< ServiceRegistry >::Instance();
 
@@ -520,9 +520,9 @@ PsmTrace::PsmTrace(Id rid, const ProtocolSM& psm) :
 
 //------------------------------------------------------------------------------
 
-bool PsmTrace::Display(ostream& stream)
+bool PsmTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    auto reg = Singleton< FactoryRegistry >::Instance();
 
@@ -560,9 +560,9 @@ PortTrace::PortTrace(Id rid, const MsgPort& port) :
 
 //------------------------------------------------------------------------------
 
-bool PortTrace::Display(ostream& stream)
+bool PortTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    auto reg = Singleton< FactoryRegistry >::Instance();
 
@@ -633,9 +633,9 @@ MsgTrace::MsgTrace(Id rid, const Message& msg, Message::Route route) :
 
 //------------------------------------------------------------------------------
 
-bool MsgTrace::Display(ostream& stream)
+bool MsgTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    stream << OutputId("port=", locAddr_.bid);
 
@@ -694,9 +694,9 @@ TimerTrace::TimerTrace(Id rid, const Timer& tmr) :
 
 //------------------------------------------------------------------------------
 
-bool TimerTrace::Display(ostream& stream)
+bool TimerTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    stream << OutputId("id=", tid_);
    stream << "secs=" << secs_ << " psm=" << psm_;
@@ -744,9 +744,9 @@ EventTrace::EventTrace(size_t size, const Event& evt) :
 
 //------------------------------------------------------------------------------
 
-bool EventTrace::Display(ostream& stream)
+bool EventTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    stream << spaces(TraceDump::ObjToDesc);
    DisplayEvent(stream, owner_, eid_);
@@ -821,9 +821,9 @@ HandlerTrace::HandlerTrace(size_t size, ServiceId sid,
 
 //------------------------------------------------------------------------------
 
-bool HandlerTrace::Display(ostream& stream)
+bool HandlerTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    stream << rc_ << spaces(4);
    DisplayEvent(stream, sid_, eid_);
@@ -865,9 +865,9 @@ SxpTrace::SxpTrace
 
 //------------------------------------------------------------------------------
 
-bool SxpTrace::Display(ostream& stream)
+bool SxpTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    stream << rc_ << spaces(4);
    DisplayEvent(stream, sid_, eid_);
@@ -893,9 +893,9 @@ SipTrace::SipTrace
 
 //------------------------------------------------------------------------------
 
-bool SipTrace::Display(ostream& stream)
+bool SipTrace::Display(ostream& stream, bool diff)
 {
-   if(!SboTrace::Display(stream)) return false;
+   if(!SboTrace::Display(stream, diff)) return false;
 
    stream << rc_ << spaces(4);
    DisplayEvent(stream, sid_, eid_);

--- a/sb/SbTrace.h
+++ b/sb/SbTrace.h
@@ -90,7 +90,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string for displaying this type of record.
    //
@@ -179,7 +179,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  For an incoming (outgoing) message, returns the identifier of the
    //  factory that received (sent) the message.
@@ -200,8 +200,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   BuffTrace(const BuffTrace& that);
-   BuffTrace& operator=(const BuffTrace& that);
+   BuffTrace(const BuffTrace& that) = delete;
+   BuffTrace& operator=(const BuffTrace& that) = delete;
 
    //  A clone of the buffer being captured.
    //
@@ -229,7 +229,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 protected:
    //  Creates a trace record for SBO, with the SIZE specified.
    //  Protected because this class is virtual.
@@ -267,7 +267,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string for displaying this type of record.
    //
@@ -296,7 +296,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string for displaying this type of record.
    //
@@ -329,7 +329,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string for displaying this type of record.
    //
@@ -375,7 +375,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string for displaying this type of record.
    //
@@ -428,7 +428,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  Overridden to return a string for displaying this type of record.
    //
@@ -473,7 +473,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 protected:
    //  For subclasses.
    //
@@ -515,7 +515,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 protected:
    //  For subclasses.
    //
@@ -553,7 +553,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  The event identifier for the SAP or SNP's currEvent_.
    //
@@ -574,7 +574,7 @@ public:
 
    //  Overridden to display the trace record.
    //
-   virtual bool Display(std::ostream& stream) override;
+   virtual bool Display(std::ostream& stream, bool diff) override;
 private:
    //  The service whose initiation was requested.
    //

--- a/sb/Service.h
+++ b/sb/Service.h
@@ -210,8 +210,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   Service(const Service& that);
-   Service& operator=(const Service& that);
+   Service(const Service& that) = delete;
+   Service& operator=(const Service& that) = delete;
 
    //  The service's identifier.
    //

--- a/sb/Signal.h
+++ b/sb/Signal.h
@@ -110,8 +110,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   Signal(const Signal& that);
-   Signal& operator=(const Signal& that);
+   Signal(const Signal& that) = delete;
+   Signal& operator=(const Signal& that) = delete;
 
    //  The protocol to which the signal belongs.
    //

--- a/sb/State.h
+++ b/sb/State.h
@@ -105,8 +105,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   State(const State& that);
-   State& operator=(const State& that);
+   State(const State& that) = delete;
+   State& operator=(const State& that) = delete;
 
    //  The state's identifier.
    //

--- a/sb/TimerRegistry.h
+++ b/sb/TimerRegistry.h
@@ -77,8 +77,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   TimerRegistry(const TimerRegistry& that);
-   TimerRegistry& operator=(const TimerRegistry& that);
+   TimerRegistry(const TimerRegistry& that) = delete;
+   TimerRegistry& operator=(const TimerRegistry& that) = delete;
 
    //  timerq_[s] contains timers expiring in (s - nextQid_) seconds; the
    //  last queue is for timers of Timer::MaxQId seconds or more.

--- a/sb/Trigger.h
+++ b/sb/Trigger.h
@@ -110,8 +110,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   Trigger(const Trigger& that);
-   Trigger& operator=(const Trigger& that);
+   Trigger(const Trigger& that) = delete;
+   Trigger& operator=(const Trigger& that) = delete;
 
    //  The identifier for this trigger.
    //

--- a/sn/PotsTreatments.h
+++ b/sn/PotsTreatments.h
@@ -105,8 +105,8 @@ public:
 private:
    //  Deleted to prohibit copying.
    //
-   PotsTreatmentQueue(const PotsTreatmentQueue& that);
-   PotsTreatmentQueue& operator=(const PotsTreatmentQueue& that);
+   PotsTreatmentQueue(const PotsTreatmentQueue& that) = delete;
+   PotsTreatmentQueue& operator=(const PotsTreatmentQueue& that) = delete;
 
    //  The queue's index in PotsTreatmentRegistry.
    //
@@ -153,8 +153,8 @@ protected:
 private:
    //  Deleted to prohibit copying.
    //
-   PotsTreatment(const PotsTreatment& that);
-   PotsTreatment& operator=(const PotsTreatment& that);
+   PotsTreatment(const PotsTreatment& that) = delete;
+   PotsTreatment& operator=(const PotsTreatment& that) = delete;
 
    //  The identifier of the PotsTreatmentQueue in which the treatment appears.
    //

--- a/st/MscBuilder.cpp
+++ b/st/MscBuilder.cpp
@@ -1099,8 +1099,8 @@ bool MscBuilder::OutputMessage
 
       if(mt.NoCtx()) active = sender;
       start = sender->Column();
-      txmsgTime = mt.GetTime();
-      if(tt != nullptr) transTime = tt->GetTime();
+      txmsgTime = mt.GetTime(false);
+      if(tt != nullptr) transTime = tt->GetTime(false);
 
       //  If the message was sent to self, the sender is also the receiver.
       //  The message will start one column to the sender's left and end at
@@ -1203,8 +1203,8 @@ bool MscBuilder::OutputMessage
 
       start = sender->Column();
       end = receiver->Column();
-      rxnetTime = tt->GetTime();
-      transTime = mt.GetTime();
+      rxnetTime = tt->GetTime(false);
+      transTime = mt.GetTime(false);
    }
 
    //  Find the message's signal so that it can be displayed.  Strip out
@@ -1337,7 +1337,7 @@ void MscBuilder::OutputTrailer() const
    buff->SetTool(TransTracer, true);
    buff->SetTool(ContextTracer, true);
    *stream_ << CRLF;
-   Singleton< TraceBuffer >::Instance()->DisplayTrace(stream_);
+   Singleton< TraceBuffer >::Instance()->DisplayTrace(stream_, false);
    *stream_ << MscTrailer;
    buff->SetTools(tools);
 }

--- a/st/MscBuilder.h
+++ b/st/MscBuilder.h
@@ -232,8 +232,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   MscBuilder(const MscBuilder& that);
-   MscBuilder& operator=(const MscBuilder& that);
+   MscBuilder(const MscBuilder& that) = delete;
+   MscBuilder& operator=(const MscBuilder& that) = delete;
 
    //  Set if internal data structures are to be displayed.
    //

--- a/st/StTestData.h
+++ b/st/StTestData.h
@@ -88,8 +88,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   StTestData(const StTestData& that);
-   StTestData& operator=(const StTestData& that);
+   StTestData(const StTestData& that) = delete;
+   StTestData& operator=(const StTestData& that) = delete;
 
    //  Whether the >verify command is currently enabled.
    //

--- a/st/TestSessions.h
+++ b/st/TestSessions.h
@@ -368,8 +368,8 @@ private:
 
    //  Deleted to prohibit copying.
    //
-   TestSession(const TestSession& that);
-   TestSession& operator=(const TestSession& that);
+   TestSession(const TestSession& that) = delete;
+   TestSession& operator=(const TestSession& that) = delete;
 
    //  The instance of StTestData to which this session belongs.
    //


### PR DESCRIPTION
1. Enhance `>save` with option to suppress timing information in order to reduce noise in *diffs*.
2. Many functions were omitted when `=delete` was introduced.